### PR TITLE
serialize enums

### DIFF
--- a/JSONAPI.Tests/Json/JsonApiMediaFormaterTests.cs
+++ b/JSONAPI.Tests/Json/JsonApiMediaFormaterTests.cs
@@ -73,6 +73,11 @@ namespace JSONAPI.Tests.Json
 
         }
 
+        private enum TestEnum
+        {
+            
+        }
+
         [TestMethod]
         public void CanWritePrimitiveTest()
         {
@@ -89,6 +94,8 @@ namespace JSONAPI.Tests.Json
             Assert.IsTrue(formatter.CanWriteTypeAsPrimitive(typeof(DateTime?)), "CanWriteTypeAsPrimitive returned wrong answer for nullable DateTime!");
             Assert.IsTrue(formatter.CanWriteTypeAsPrimitive(typeof(DateTimeOffset?)), "CanWriteTypeAsPrimitive returned wrong answer for nullable DateTimeOffset!");
             Assert.IsTrue(formatter.CanWriteTypeAsPrimitive(typeof(Guid?)), "CanWriteTypeAsPrimitive returned wrong answer for nullable Guid!");
+            Assert.IsTrue(formatter.CanWriteTypeAsPrimitive(typeof(TestEnum)), "CanWriteTypeAsPrimitive returned wrong answer for enum!");
+            Assert.IsTrue(formatter.CanWriteTypeAsPrimitive(typeof(TestEnum?)), "CanWriteTypeAsPrimitive returned wrong answer for nullable enum!");
             Assert.IsFalse(formatter.CanWriteTypeAsPrimitive(typeof(Object)), "CanWriteTypeAsPrimitive returned wrong answer for Object!");
         }
 

--- a/JSONAPI/Json/JsonApiFormatter.cs
+++ b/JSONAPI/Json/JsonApiFormatter.cs
@@ -55,6 +55,10 @@ namespace JSONAPI.Json
                 || typeof(System.DateTime?).IsAssignableFrom(objectType)
                 || typeof(System.DateTimeOffset?).IsAssignableFrom(objectType)
                 || typeof(String).IsAssignableFrom(objectType)
+                || objectType.IsEnum
+                || (objectType.IsGenericType &&
+                    objectType.GetGenericTypeDefinition() == typeof(Nullable<>) &&
+                    objectType.GetGenericArguments()[0].IsEnum)
                 )
                 return true;
             else return false;


### PR DESCRIPTION
This PR allows serializing enum and nullable enum properties as primitive types. At the moment, the formatter treats them as linked resources, when they should probably be sent as integers instead.