### PR TITLE
serialize arrays

### DIFF
--- a/JSONAPI.Tests/Json/JsonApiMediaFormaterTests.cs
+++ b/JSONAPI.Tests/Json/JsonApiMediaFormaterTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using JSONAPI.Tests.Models;
 using Newtonsoft.Json;
@@ -109,6 +110,31 @@ namespace JSONAPI.Tests.Json
             //Payload payload = new Payload(a.Posts);
             //js.Serialize(jw, payload);
             formatter.WriteToStreamAsync(typeof(Post), a.Posts, stream, (System.Net.Http.HttpContent)null, (System.Net.TransportContext)null);
+
+            // Assert
+            string output = System.Text.Encoding.ASCII.GetString(stream.ToArray());
+            Trace.WriteLine(output);
+            Assert.AreEqual(output.Trim(), File.ReadAllText("SerializerIntegrationTest.json").Trim());
+            //Assert.AreEqual("[2,3,4]", sw.ToString());
+        }
+
+        [TestMethod]
+        [DeploymentItem(@"Data\SerializerIntegrationTest.json")]
+        public void SerializeArrayIntegrationTest()
+        {
+            // Arrange
+            //PayloadConverter pc = new PayloadConverter();
+            //ModelConverter mc = new ModelConverter();
+            //ContractResolver.PluralizationService = new PluralizationService();
+
+            JsonApiFormatter formatter = new JSONAPI.Json.JsonApiFormatter();
+            formatter.PluralizationService = new JSONAPI.Core.PluralizationService();
+            MemoryStream stream = new MemoryStream();
+
+            // Act
+            //Payload payload = new Payload(a.Posts);
+            //js.Serialize(jw, payload);
+            formatter.WriteToStreamAsync(typeof(Post), a.Posts.ToArray(), stream, (System.Net.Http.HttpContent)null, (System.Net.TransportContext)null);
 
             // Assert
             string output = System.Text.Encoding.ASCII.GetString(stream.ToArray());

--- a/JSONAPI/Json/JsonApiFormatter.cs
+++ b/JSONAPI/Json/JsonApiFormatter.cs
@@ -759,8 +759,9 @@ namespace JSONAPI.Json
 
         private bool IsMany(Type type)
         {
-            //TODO: Should we check for arrays also? (They aren't generics.)
-            return (type.GetInterfaces().Contains(typeof(IEnumerable)) && type.IsGenericType);
+            return
+                type.IsArray ||
+                (type.GetInterfaces().Contains(typeof(IEnumerable)) && type.IsGenericType);
         }
 
         private Type GetSingleType(Type type)//dynamic value = null)


### PR DESCRIPTION
At the moment only generic enumerable types can be serialized as resource collections. This PR allows serializing arrays also.