### PR TITLE
do not serialize primitive type properties that have a JsonIgnore attribute

### DIFF
--- a/JSONAPI/Json/JsonApiFormatter.cs
+++ b/JSONAPI/Json/JsonApiFormatter.cs
@@ -147,6 +147,9 @@ namespace JSONAPI.Json
 
                 if (this.CanWriteTypeAsPrimitive(prop.PropertyType))
                 {
+                    if (prop.GetCustomAttributes().Any(attr => attr is JsonIgnoreAttribute))
+                        continue;
+
                     // numbers, strings, dates...
                     writer.WritePropertyName(FormatPropertyName(prop.Name));
                     serializer.Serialize(writer, prop.GetValue(value, null));


### PR DESCRIPTION
This PR ensures that primitive-type properties that have a JsonIgnore attribute are not serialized. Previously, only navigation properties would be ignored if they had this attribute.