### PR TITLE
Send link as href in embedded object

### DIFF
--- a/JSONAPI.Tests/Data/LinkTemplateTest.json
+++ b/JSONAPI.Tests/Data/LinkTemplateTest.json
@@ -1,0 +1,11 @@
+{
+    "posts": {
+        "id": "2",
+        "title": "How to fry an egg",
+        "links": {
+            "author": {
+                "href": "/users/5"
+            }
+        }
+    }
+}

--- a/JSONAPI.Tests/JSONAPI.Tests.csproj
+++ b/JSONAPI.Tests/JSONAPI.Tests.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Json\ErrorSerializerTests.cs" />
     <Compile Include="Json\JsonApiMediaFormaterTests.cs" />
     <Compile Include="Json\JsonHelpers.cs" />
+    <Compile Include="Json\LinkTemplateTests.cs" />
     <Compile Include="Models\Author.cs" />
     <Compile Include="Models\Comment.cs" />
     <Compile Include="Models\Post.cs" />
@@ -96,6 +97,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="Data\ErrorSerializerTest.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="Data\LinkTemplateTest.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="Data\SerializerIntegrationTest.json">

--- a/JSONAPI.Tests/Json/LinkTemplateTests.cs
+++ b/JSONAPI.Tests/Json/LinkTemplateTests.cs
@@ -1,0 +1,67 @@
+﻿using JSONAPI.Attributes;
+using JSONAPI.Json;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+
+namespace JSONAPI.Tests.Json
+{
+    [TestClass]
+    public class LinkTemplateTests
+    {
+        private class Post
+        {
+            public string Id { get; set; }
+
+            public string Title { get; set; }
+
+            [SerializeAs(SerializeAsOptions.Link)]
+            [LinkTemplate("/users/{0}")]
+            public virtual User Author { get; set; }
+        }
+
+        private class User
+        {
+            public string Id { get; set; }
+
+            public string Name { get; set; }
+        }
+
+        private Post ThePost { get; set; }
+
+        [TestInitialize]
+        public void SetupModels()
+        {
+            ThePost = new Post
+            {
+                Id = "2",
+                Title = "How to fry an egg",
+                Author = new User
+                {
+                    Id = "5",
+                    Name = "Bob"
+                }
+            };
+        }
+
+        [TestMethod]
+        [DeploymentItem(@"Data\LinkTemplateTest.json")]
+        public void GetResourceWithLinkTemplateRelationship()
+        {
+            var formatter = new JsonApiFormatter
+            {
+                PluralizationService = new JSONAPI.Core.PluralizationService()
+            };
+            var stream = new MemoryStream();
+
+            formatter.WriteToStreamAsync(typeof(Post), ThePost, stream, null, null);
+
+            // Assert
+            var expected = JsonHelpers.MinifyJson(File.ReadAllText("LinkTemplateTest.json"));
+            var output = Encoding.ASCII.GetString(stream.ToArray());
+            Trace.WriteLine(output);
+            Assert.AreEqual(output.Trim(), expected);
+        }
+    }
+}

--- a/JSONAPI/Json/JsonApiFormatter.cs
+++ b/JSONAPI/Json/JsonApiFormatter.cs
@@ -296,7 +296,10 @@ namespace JSONAPI.Json
                                 string link = String.Format(lt, objId,
                                     value.GetType().GetProperty("Id").GetValue(value, null));
                                 //writer.WritePropertyName(ContractResolver.FormatPropertyName(prop.Name));
+                                writer.WriteStartObject();
+                                writer.WritePropertyName("href");
                                 writer.WriteValue(link);
+                                writer.WriteEndObject();
                                 break;
                             case SerializeAsOptions.Embedded:
                                 // Not really supported by Ember Data yet, incidentally...but easy to implement here.


### PR DESCRIPTION
According to the spec, sending a link should look like this:

```
{
    "posts": {
        "id": "2",
        "title": "How to fry an egg",
        "links": {
            "author": {
                "href": "/users/5"
            }
        }
    }
}
```

The formatter is currently sending:

```
{
    "posts": {
        "id": "2",
        "title": "How to fry an egg",
        "links": {
            "author": "/users/5"
        }
    }
}
```

There is no way for the client to tell that that is a link and not an ID. This PR changes the handling for `[SerializeAs(SerializeAsOptions.Link)]` to put the link on an `href` key in an embedded object.

I needed the json minifier helper from #8, so I included it here as a separate commit. I may need to rebase one of these PRs when you merge the other.