### PR TITLE
rearrange constructors

### DIFF
--- a/JSONAPI/Json/JsonApiFormatter.cs
+++ b/JSONAPI/Json/JsonApiFormatter.cs
@@ -20,27 +20,32 @@ namespace JSONAPI.Json
     public class JsonApiFormatter : JsonMediaTypeFormatter
     {
         public JsonApiFormatter()
-            : this(new ErrorSerializer())
+            : this(new ModelManager(), new ErrorSerializer())
         {
-            if (_modelManager == null) _modelManager = new ModelManager();
-            SupportedMediaTypes.Add(new MediaTypeHeaderValue("application/vnd.api+json"));
+        }
+
+        public JsonApiFormatter(IModelManager modelManager) :
+            this(modelManager, new ErrorSerializer())
+        {
+        }
+
+        public JsonApiFormatter(IPluralizationService pluralizationService) :
+            this(new ModelManager(pluralizationService))
+        {
         }
 
         // Currently for tests only.
         internal JsonApiFormatter(IErrorSerializer errorSerializer)
+            : this(new ModelManager(), errorSerializer)
         {
-            _modelManager = new ModelManager(new PluralizationService());
-            _errorSerializer = errorSerializer;
+            
         }
 
-        public JsonApiFormatter(IModelManager modelManager) : this()
+        internal JsonApiFormatter(IModelManager modelManager, IErrorSerializer errorSerializer)
         {
             _modelManager = modelManager;
-        }
-
-        public JsonApiFormatter(IPluralizationService pluralizationService) : this()
-        {
-            _modelManager = new ModelManager(pluralizationService);
+            _errorSerializer = errorSerializer;
+            SupportedMediaTypes.Add(new MediaTypeHeaderValue("application/vnd.api+json"));
         }
 
         [Obsolete]


### PR DESCRIPTION
This is a PR against your PR #25. I think this is a better set of constructors. It isolates all the changes against the current class into one constructor, and I think it makes it clearer what exactly is going on. It also gives tests a more flexible interface for mocking dependencies.

I'm leaving the 2-param constructor internal for now, but we can open it up later if we decide to let users customize error serialization.