### PR TITLE
fix bug in GetJsonKeyForType

### DIFF
--- a/JSONAPI.Tests/Core/ModelManagerTests.cs
+++ b/JSONAPI.Tests/Core/ModelManagerTests.cs
@@ -54,11 +54,13 @@ namespace JSONAPI.Tests.Core
             var postKey = mm.GetJsonKeyForType(typeof(Post));
             var authorKey = mm.GetJsonKeyForType(typeof(Author));
             var commentKey = mm.GetJsonKeyForType(typeof(Comment));
+            var manyCommentKey = mm.GetJsonKeyForType(typeof(Comment[]));
 
             // Assert
             Assert.AreEqual("posts", postKey);
             Assert.AreEqual("authors", authorKey);
             Assert.AreEqual("comments", commentKey);
+            Assert.AreEqual("comments", manyCommentKey);
         }
 
         [TestMethod]

--- a/JSONAPI/Core/ModelManager.cs
+++ b/JSONAPI/Core/ModelManager.cs
@@ -127,10 +127,10 @@ namespace JSONAPI.Core
 
             lock (keyCache)
             {
-                if (keyCache.TryGetValue(type, out key)) return key;
-
                 if (IsSerializedAsMany(type))
                     type = GetElementType(type);
+
+                if (keyCache.TryGetValue(type, out key)) return key;
 
                 var attrs = type.CustomAttributes.Where(x => x.AttributeType == typeof(Newtonsoft.Json.JsonObjectAttribute)).ToList();
 


### PR DESCRIPTION
If you try to call `ModelManager.GetJsonKeyForType()` for a single type, and then call it for an array of that same type, it will throw an error because it is trying to add to the cache a key that already exists.