### PR TITLE
add safeguards against invalid raw json strings

### DIFF
--- a/JSONAPI.Tests/Data/MalformedRawJsonString.json
+++ b/JSONAPI.Tests/Data/MalformedRawJsonString.json
@@ -1,0 +1,12 @@
+{
+    "comments": [
+        {
+            "id": "5",
+            "body": null,
+            "customData": { },
+            "links": { 
+                "post":  null
+            }
+        }
+    ]
+}

--- a/JSONAPI.Tests/Data/ReformatsRawJsonStringWithUnquotedKeys.json
+++ b/JSONAPI.Tests/Data/ReformatsRawJsonStringWithUnquotedKeys.json
@@ -1,0 +1,14 @@
+{
+    "comments": [
+        {
+            "id": "5",
+            "body": null,
+            "customData": { 
+                "unquotedKey":  5
+            },
+            "links": {
+                "post": null
+            }
+        }
+    ]
+}

--- a/JSONAPI.Tests/JSONAPI.Tests.csproj
+++ b/JSONAPI.Tests/JSONAPI.Tests.csproj
@@ -96,6 +96,12 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
+    <None Include="Data\ReformatsRawJsonStringWithUnquotedKeys.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="Data\MalformedRawJsonString.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="Data\FormatterErrorSerializationTest.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/JSONAPI.Tests/Json/JsonApiMediaFormaterTests.cs
+++ b/JSONAPI.Tests/Json/JsonApiMediaFormaterTests.cs
@@ -251,6 +251,44 @@ namespace JSONAPI.Tests.Json
         }
 
         [TestMethod]
+        [DeploymentItem(@"Data\ReformatsRawJsonStringWithUnquotedKeys.json")]
+        public void Reformats_raw_json_string_with_unquoted_keys()
+        {
+            // Arrange
+            JsonApiFormatter formatter = new JsonApiFormatter(new PluralizationService());
+            MemoryStream stream = new MemoryStream();
+
+            // Act
+            var payload = new [] { new Comment { Id = 5, CustomData = "{ unquotedKey: 5 }"}};
+            formatter.WriteToStreamAsync(typeof(Comment), payload, stream, null, null);
+
+            // Assert
+            var minifiedExpectedJson = JsonHelpers.MinifyJson(File.ReadAllText("ReformatsRawJsonStringWithUnquotedKeys.json"));
+            string output = System.Text.Encoding.ASCII.GetString(stream.ToArray());
+            Trace.WriteLine(output);
+            output.Should().Be(minifiedExpectedJson);
+        }
+
+        [TestMethod]
+        [DeploymentItem(@"Data\MalformedRawJsonString.json")]
+        public void Does_not_serialize_malformed_raw_json_string()
+        {
+            // Arrange
+            JsonApiFormatter formatter = new JsonApiFormatter(new PluralizationService());
+            MemoryStream stream = new MemoryStream();
+
+            // Act
+            var payload = new[] { new Comment { Id = 5, CustomData = "{ x }" } };
+            formatter.WriteToStreamAsync(typeof(Comment), payload, stream, null, null);
+
+            // Assert
+            var minifiedExpectedJson = JsonHelpers.MinifyJson(File.ReadAllText("MalformedRawJsonString.json"));
+            string output = System.Text.Encoding.ASCII.GetString(stream.ToArray());
+            Trace.WriteLine(output);
+            output.Should().Be(minifiedExpectedJson);
+        }
+
+        [TestMethod]
         [DeploymentItem(@"Data\FormatterErrorSerializationTest.json")]
         public void Should_serialize_error()
         {

--- a/JSONAPI/Json/JsonApiFormatter.cs
+++ b/JSONAPI/Json/JsonApiFormatter.cs
@@ -42,7 +42,10 @@ namespace JSONAPI.Json
             _modelManager = modelManager;
             _errorSerializer = errorSerializer;
             SupportedMediaTypes.Add(new MediaTypeHeaderValue("application/vnd.api+json"));
+            ValidateRawJsonStrings = true;
         }
+
+        public bool ValidateRawJsonStrings { get; set; }
 
         [Obsolete("Use ModelManager.PluralizationService instead")]
         public IPluralizationService PluralizationService  //FIXME: Deprecated, will be removed shortly
@@ -212,8 +215,21 @@ namespace JSONAPI.Json
                         }
                         else
                         {
-                            var minifiedValue = JsonHelpers.MinifyJson((string) propertyValue);
-                            writer.WriteRawValue(minifiedValue);
+                            var json = (string) propertyValue;
+                            if (ValidateRawJsonStrings)
+                            {
+                                try
+                                {
+                                    var token = JToken.Parse(json);
+                                    json = token.ToString();
+                                }
+                                catch (Exception)
+                                {
+                                    json = "{}";
+                                }
+                            }
+                            var valueToSerialize = JsonHelpers.MinifyJson(json);
+                            writer.WriteRawValue(valueToSerialize);
                         }
                     }
                     else


### PR DESCRIPTION
I realized that my code that serializes raw JSON down from the database has no protections to ensure that the data is actually valid JSON. If it's malformed in any way, the formatter will happily send it onto the wire and the client will choke on the response.

I added a check that validates raw json properties before they are serialized. If the property value contains unparseable syntax, like `{ x }`, then the entire object will be sent down as an empty hash `{}`. If the property value contains unquoted keys, then the keys will be quoted. So `{ foo: 3 }` will be serialized as `{ "foo": 3 }`.

(I originally wanted to have the same behavior if we detect unquoted keys as if the JSON is malformed. But I don't think it's possible to make Json.NET do this - the JToken parser just converts the unquoted keys into quoted ones instead of throwing an exception.)