### PR TITLE
[WIP] Allows runtime overriding of certain serialization attributes

### DIFF
--- a/JSONAPI.Tests/Data/OverrideSerializationAttributesTest.json
+++ b/JSONAPI.Tests/Data/OverrideSerializationAttributesTest.json
@@ -1,0 +1,17 @@
+﻿{
+    "posts": {
+        "id": "2",
+        "title": "How to fry an egg",
+        "links": {
+            "author": "5"
+        }
+    },
+    "linked": {
+        "users": [
+            {
+                "id": "5",
+                "name": "Bob"
+            }
+        ]
+    }
+}

--- a/JSONAPI.Tests/JSONAPI.Tests.csproj
+++ b/JSONAPI.Tests/JSONAPI.Tests.csproj
@@ -109,6 +109,9 @@
     <None Include="Data\NonStandardIdTest.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="Data\OverrideSerializationAttributesTest.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="Data\SerializerIntegrationTest.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/JSONAPI.Tests/Json/LinkTemplateTests.cs
+++ b/JSONAPI.Tests/Json/LinkTemplateTests.cs
@@ -61,7 +61,33 @@ namespace JSONAPI.Tests.Json
             var expected = JsonHelpers.MinifyJson(File.ReadAllText("LinkTemplateTest.json"));
             var output = Encoding.ASCII.GetString(stream.ToArray());
             Trace.WriteLine(output);
-            Assert.AreEqual(output.Trim(), expected);
+            Assert.AreEqual(expected,output.Trim());
+        }
+
+        [TestMethod]
+        [DeploymentItem(@"Data\OverrideSerializationAttributesTest.json")]
+        public void OverrideSerializationAttributesTest()
+        {
+            // Arrange
+            var formatter = new JsonApiFormatter
+            (
+                new JSONAPI.Core.PluralizationService()
+            );
+            var stream = new MemoryStream();
+
+            // Act
+            JSONAPI.Core.MetadataManager.Instance.SetPropertyAttributeOverrides(
+                ThePost, typeof(Post).GetProperty("Author"),
+                new SerializeAs(SerializeAsOptions.Ids),
+                new IncludeInPayload(true)
+                );
+            formatter.WriteToStreamAsync(typeof(Post), ThePost, stream, null, null);
+
+            // Assert
+            var expected = JsonHelpers.MinifyJson(File.ReadAllText("OverrideSerializationAttributesTest.json"));
+            var output = Encoding.ASCII.GetString(stream.ToArray());
+            Trace.WriteLine(output);
+            Assert.AreEqual(expected, output.Trim());
         }
     }
 }

--- a/JSONAPI/Core/MetadataManager.cs
+++ b/JSONAPI/Core/MetadataManager.cs
@@ -10,6 +10,23 @@ namespace JSONAPI.Core
 {
     public sealed class MetadataManager
     {
+        private class PropertyMetadata
+        {
+            public bool PresentInJson { get; set; } // only meaningful for incoming/deserialized models!
+            public Lazy<IEnumerable<System.Attribute>> AttributeOverrides
+                = new Lazy<IEnumerable<System.Attribute>>(
+                    () => new List<System.Attribute>()
+                );
+        }
+
+        private class ModelMetadata
+        {
+            public Lazy<IDictionary<PropertyInfo, PropertyMetadata>> PropertyMetadata
+                = new Lazy<IDictionary<PropertyInfo, PropertyMetadata>>(
+                    () => new Dictionary<PropertyInfo, PropertyMetadata>()
+                );
+        }
+
         #region Singleton pattern
 
         private static readonly MetadataManager instance = new MetadataManager();
@@ -26,8 +43,8 @@ namespace JSONAPI.Core
 
         #endregion
 
-        private readonly ConditionalWeakTable<object, Dictionary<string, object>> cwt
-            = new ConditionalWeakTable<object, Dictionary<string, object>>();
+        private readonly ConditionalWeakTable<object, ModelMetadata> cwt
+            = new ConditionalWeakTable<object, ModelMetadata>();
 
         /*
         internal void SetDeserializationMetadata(object deserialized, Dictionary<string, object> meta)
@@ -36,32 +53,40 @@ namespace JSONAPI.Core
         }
          */
 
-        internal void SetMetaForProperty(object deserialized, PropertyInfo prop, object value)
+        private ModelMetadata GetMetadataForModel(object model)
         {
-            Dictionary<string, object> meta;
-            if (!cwt.TryGetValue(deserialized, out meta))
+            ModelMetadata meta;
+            lock(cwt)
             {
-                meta = new Dictionary<string, object>();
-                cwt.Add(deserialized, meta);
+                if (!cwt.TryGetValue(model, out meta))
+                {
+                    meta = new ModelMetadata();
+                    cwt.Add(model, meta);
+                }
             }
-            if (!meta.ContainsKey(prop.Name)) // Temporary fix for non-standard Id reprecussions...this internal implementation will change soon anyway.
-                meta.Add(prop.Name, value);
-            
+            return meta;
         }
 
-
-        internal Dictionary<String, object> DeserializationMetadata(object deserialized)
+        private PropertyMetadata GetMetadataForProperty(object model, PropertyInfo prop)
         {
-            Dictionary<string, object> retval;
-            if (cwt.TryGetValue(deserialized, out retval))
+            ModelMetadata mmeta = GetMetadataForModel(model);
+            IDictionary<PropertyInfo, PropertyMetadata> pmetadict = mmeta.PropertyMetadata.Value;
+            PropertyMetadata pmeta;
+            lock (pmetadict)
             {
-                return retval;
+                if (!pmetadict.TryGetValue(prop, out pmeta))
+                {
+                    pmeta = new PropertyMetadata();
+                    pmetadict.Add(prop, pmeta);
+                }
             }
-            else
-            {
-                //TODO: Throw an exception here? If you asked for metadata for an object and it's not found, something has probably gone pretty badly wrong!
-                return null;
-            }
+            return pmeta;
+        }
+
+        internal void SetPropertyWasPresent(object deserialized, PropertyInfo prop, bool value)
+        {
+            PropertyMetadata pmeta = GetMetadataForProperty(deserialized, prop);
+            pmeta.PresentInJson = value;
         }
 
         /// <summary>
@@ -75,8 +100,8 @@ namespace JSONAPI.Core
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool PropertyWasPresent(object deserialized, PropertyInfo prop)
         {
-            object throwaway;
-            return this.DeserializationMetadata(deserialized).TryGetValue(prop.Name, out throwaway);
+            return this.GetMetadataForProperty(deserialized, prop).PresentInJson;
         }
+
     }
 }

--- a/JSONAPI/Json/JsonApiFormatter.cs
+++ b/JSONAPI/Json/JsonApiFormatter.cs
@@ -656,7 +656,7 @@ namespace JSONAPI.Json
                         prop.SetValue(retval, propVal, null);
 
                         // Tell the MetadataManager that we deserialized this property
-                        MetadataManager.Instance.SetMetaForProperty(retval, prop, true);
+                        MetadataManager.Instance.SetPropertyWasPresent(retval, prop, true);
 
                         // pop the value off the reader, so we catch the EndObject token below!.
                         reader.Read();
@@ -805,7 +805,7 @@ namespace JSONAPI.Json
                         }
 
                         // Tell the MetadataManager that we deserialized this property
-                        MetadataManager.Instance.SetMetaForProperty(obj, prop, true);
+                        MetadataManager.Instance.SetPropertyWasPresent(obj, prop, true);
                     }
                     else
                         reader.Skip();

--- a/JSONAPI/Json/JsonApiFormatter.cs
+++ b/JSONAPI/Json/JsonApiFormatter.cs
@@ -252,6 +252,8 @@ namespace JSONAPI.Json
                 SerializeAsOptions sa = SerializeAsOptions.Ids;
 
                 object[] attrs = prop.GetCustomAttributes(true);
+                // aha...this way the overrides will be applied last!
+                attrs = attrs.Concat(MetadataManager.Instance.GetPropertyAttributeOverrides(value, prop)).ToArray();
 
                 foreach (object attr in attrs)
                 {


### PR DESCRIPTION
This partly addresses #27, it provides a mechanism to set the serialization behavior defined by (for instance) `SerializeAs(...)` and `IncludeInPayload(...)`, allowing you to choose include related resources at runtime, for example when getting a single model object instead of all model objects of a type.