### PR TITLE
EF materializer nonstandard id bug

### DIFF
--- a/JSONAPI.EntityFramework.Tests/EntityFrameworkMaterializerTests.cs
+++ b/JSONAPI.EntityFramework.Tests/EntityFrameworkMaterializerTests.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using JSONAPI.EntityFramework.Tests.Models;
+using FluentAssertions;
+using System.Collections.Generic;
+
+namespace JSONAPI.EntityFramework.Tests
+{
+    [TestClass]
+    public class EntityFrameworkMaterializerTests
+    {
+        private class NotAnEntity
+        {
+            public string Id { get; set; }
+            public string Temporary { get; set; }
+        }
+
+        private TestEntities context;
+        private Backlink b1, b2;
+
+        [TestInitialize]
+        public void SetupEntities()
+        {
+            //- See http://stackoverflow.com/a/19130718/489116
+            var instance = System.Data.Entity.SqlServer.SqlProviderServices.Instance;
+            //-
+
+            context = new TestEntities();
+            //JSONAPI.EntityFramework.Json.ContractResolver.ObjectContext = context;
+
+
+            // Clear it out!
+            foreach (Backlink o in context.Backlinks) context.Backlinks.Remove(o);
+            context.SaveChanges();
+
+            b1 = new Backlink
+            {
+                Url = "http://www.google.com/",
+                Snippet = "1 Results"
+            };
+
+            context.SaveChanges();
+        }
+
+        [TestMethod]
+        public void GetKeyNamesStandardIdTest()
+        {
+            // Arrange
+            var materializer = new EntityFrameworkMaterializer(context);
+
+            // Act
+            IEnumerable<string> keyNames = materializer.GetKeyNames(typeof(Post));
+
+            // Assert
+            keyNames.Count().Should().Be(1);
+            keyNames.First().Should().Be("Id");
+        }
+
+        [TestMethod]
+        public void GetKeyNamesNonStandardIdTest()
+        {
+            // Arrange
+            var materializer = new EntityFrameworkMaterializer(context);
+
+            // Act
+            IEnumerable<string> keyNames = materializer.GetKeyNames(typeof(Backlink));
+
+            // Assert
+            keyNames.Count().Should().Be(1);
+            keyNames.First().Should().Be("Url");
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(System.ArgumentException))]
+        public void GetKeyNamesNotAnEntityTest()
+        {
+            // Arrange
+            var materializer = new EntityFrameworkMaterializer(context);
+
+            // Act
+            IEnumerable<string> keyNames = materializer.GetKeyNames(typeof(NotAnEntity));
+
+            // Assert
+            Assert.Fail("A System.ArgumentException should be thrown, this assertion should be unreachable!");
+        }
+    }
+}

--- a/JSONAPI.EntityFramework.Tests/JSONAPI.EntityFramework.Tests.csproj
+++ b/JSONAPI.EntityFramework.Tests/JSONAPI.EntityFramework.Tests.csproj
@@ -90,11 +90,13 @@
   <ItemGroup>
     <Compile Include="ActionFilters\EnumerateQueryableAsyncAttributeTests.cs" />
     <Compile Include="EntityConverterTests.cs" />
+    <Compile Include="EntityFrameworkMaterializerTests.cs" />
     <Compile Include="Helpers\TestDbAsyncEnumerable.cs" />
     <Compile Include="Helpers\WaitsUntilCancellationDbAsyncEnumerator.cs" />
     <Compile Include="Helpers\TestDbAsyncEnumerator.cs" />
     <Compile Include="Helpers\TestDbAsyncQueryProvider.cs" />
     <Compile Include="Models\Author.cs" />
+    <Compile Include="Models\Backlink.cs" />
     <Compile Include="Models\Comment.cs" />
     <Compile Include="Models\TestEntities.cs" />
     <Compile Include="Models\Post.cs" />

--- a/JSONAPI.EntityFramework.Tests/Models/Backlink.cs
+++ b/JSONAPI.EntityFramework.Tests/Models/Backlink.cs
@@ -1,0 +1,18 @@
+﻿using JSONAPI.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace JSONAPI.EntityFramework.Tests.Models
+{
+    public class Backlink
+    {
+        [UseAsId]
+        [System.ComponentModel.DataAnnotations.Key]
+        public string Url { get; set; }
+
+        public Post Post { get; set; }
+        public string Snippet { get; set; }
+    }
+}

--- a/JSONAPI.EntityFramework.Tests/Models/TestEntities.cs
+++ b/JSONAPI.EntityFramework.Tests/Models/TestEntities.cs
@@ -6,6 +6,8 @@
     
     public partial class TestEntities : DbContext
     {
+        private class TestEntitiesInitializer : DropCreateDatabaseIfModelChanges<TestEntities> { }
+
         public TestEntities()
             : base("name=TestEntities")
         {
@@ -13,11 +15,12 @@
     
         protected override void OnModelCreating(DbModelBuilder modelBuilder)
         {
-            //throw new UnintentionalCodeFirstException();
+            Database.SetInitializer<TestEntities>(new TestEntitiesInitializer());
         }
     
         public virtual DbSet<Author> Authors { get; set; }
         public virtual DbSet<Post> Posts { get; set; }
         public virtual DbSet<Comment> Comments { get; set; }
+        public virtual DbSet<Backlink> Backlinks { get; set; }
     }
 }

--- a/JSONAPI.EntityFramework/Properties/AssemblyInfo.cs
+++ b/JSONAPI.EntityFramework/Properties/AssemblyInfo.cs
@@ -22,6 +22,8 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("cdabab0c-3332-4b93-8cb6-ad521265a701")]
 
+[assembly: InternalsVisibleTo("JSONAPI.EntityFramework.Tests")]
+
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version


### PR DESCRIPTION
`GetKeyNames` was completely broken, actually: it was always returning only `Id`, and swallowing an exception on every run. Now it properly checks for several conditions, and has tests to back it up.

Also fixed `TestEntities` to be able to delete the DB and recreate the model if it changes (which it did in this commit).