### PR TITLE
Add sorting action filter

### DIFF
--- a/JSONAPI.EntityFramework.Tests.TestWebApp/Models/User.cs
+++ b/JSONAPI.EntityFramework.Tests.TestWebApp/Models/User.cs
@@ -8,7 +8,9 @@ namespace JSONAPI.EntityFramework.Tests.TestWebApp.Models
         [Key]
         public string Id { get; set; }
 
-        public string Name { get; set; }
+        public string FirstName { get; set; }
+
+        public string LastName { get; set; }
 
         public virtual ICollection<Comment> Comments { get; set; }
 

--- a/JSONAPI.EntityFramework.Tests.TestWebApp/Startup.cs
+++ b/JSONAPI.EntityFramework.Tests.TestWebApp/Startup.cs
@@ -73,6 +73,7 @@ namespace JSONAPI.EntityFramework.Tests.TestWebApp
 
             // Global filters
             config.Filters.Add(new EnumerateQueryableAsyncAttribute());
+            config.Filters.Add(new EnableSortingAttribute(modelManager));
             config.Filters.Add(new EnableFilteringAttribute(modelManager));
 
             // Override controller selector

--- a/JSONAPI.EntityFramework.Tests/Acceptance/AcceptanceTestsBase.cs
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/AcceptanceTestsBase.cs
@@ -3,6 +3,7 @@ using System.Data.Common;
 using System.Net;
 using System.Net.Http;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using FluentAssertions;
 using JSONAPI.EntityFramework.Tests.TestWebApp;
@@ -16,6 +17,7 @@ namespace JSONAPI.EntityFramework.Tests.Acceptance
     [TestClass]
     public abstract class AcceptanceTestsBase
     {
+        private static readonly Regex GuidRegex = new Regex(@"\b[A-F0-9]{8}(?:-[A-F0-9]{4}){3}-[A-F0-9]{12}\b", RegexOptions.IgnoreCase);
         private static readonly Uri BaseUri = new Uri("http://localhost");
 
         protected static DbConnection GetEffortConnection()
@@ -23,7 +25,33 @@ namespace JSONAPI.EntityFramework.Tests.Acceptance
             return TestHelpers.GetEffortConnection(@"Acceptance\Data");
         }
 
-        protected async Task TestGet(DbConnection effortConnection, string requestPath, string expectedResponseTextResourcePath)
+        protected async Task ExpectGetToSucceed(DbConnection effortConnection, string requestPath,
+            string expectedResponseTextResourcePath)
+        {
+            var response = await GetEndpointResponse(effortConnection, requestPath);
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            var responseContent = await response.Content.ReadAsStringAsync();
+
+            var expected =
+                JsonHelpers.MinifyJson(TestHelpers.ReadEmbeddedFile(expectedResponseTextResourcePath));
+            responseContent.Should().Be(expected);
+        }
+
+        protected async Task ExpectGetToFail(DbConnection effortConnection, string requestPath,
+            string expectedResponseTextResourcePath, HttpStatusCode expectedStatusCode = HttpStatusCode.BadRequest)
+        {
+            var expectedResponse = JsonHelpers.MinifyJson(TestHelpers.ReadEmbeddedFile(expectedResponseTextResourcePath));
+            var response = await GetEndpointResponse(effortConnection, requestPath);
+            response.StatusCode.Should().Be(expectedStatusCode);
+
+            var responseContent = await response.Content.ReadAsStringAsync();
+            var redactedResponse = GuidRegex.Replace(responseContent, "{{SOME_GUID}}");
+
+            redactedResponse.Should().Be(expectedResponse);
+        }
+
+        protected async Task<HttpResponseMessage> GetEndpointResponse(DbConnection effortConnection, string requestPath)
         {
             using (var server = TestServer.Create(app =>
             {
@@ -33,12 +61,7 @@ namespace JSONAPI.EntityFramework.Tests.Acceptance
             {
                 var uri = new Uri(BaseUri, requestPath);
                 var response = await server.CreateRequest(uri.ToString()).GetAsync();
-                response.StatusCode.Should().Be(HttpStatusCode.OK);
-                var responseContent = await response.Content.ReadAsStringAsync();
-
-                var expected =
-                    JsonHelpers.MinifyJson(TestHelpers.ReadEmbeddedFile(expectedResponseTextResourcePath));
-                responseContent.Should().Be(expected);
+                return response;
             }
         }
 

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Data/User.csv
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Data/User.csv
@@ -1,4 +1,11 @@
-﻿Id,Name
-"401","Alice"
-"402","Bob"
-"403","Charlie"
+﻿Id,FirstName,LastName
+"401","Alice","Smith"
+"402","Bob","Jones"
+"403","Charlie","Michaels"
+"404","Richard","Smith"
+"405","Michelle","Johnson"
+"406","Ed","Burns"
+"407","Thomas","Potter"
+"408","Pat","Morgan"
+"409","Charlie","Burns"
+"410","Sally","Burns"

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Users_GetSortedAscendingResponse.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Users_GetSortedAscendingResponse.json
@@ -1,0 +1,104 @@
+﻿{
+    "users": [
+        {
+            "id": "401",
+            "firstName": "Alice",
+            "lastName": "Smith",
+            "links": {
+                "comments": [ "105" ],
+                "posts": [ "201", "202", "203" ],
+                "userGroups": [ ]
+            }
+        },
+        {
+            "id": "402",
+            "firstName": "Bob",
+            "lastName": "Jones",
+            "links": {
+                "comments": [ "102" ],
+                "posts": [ "204" ],
+                "userGroups": [ ]
+            }
+        },
+        {
+            "id": "403",
+            "firstName": "Charlie",
+            "lastName": "Michaels",
+            "links": {
+                "comments": [ "101", "103", "104" ],
+                "posts": [ ],
+                "userGroups": [ ]
+            }
+        },
+        {
+            "id": "409",
+            "firstName": "Charlie",
+            "lastName": "Burns",
+            "links": {
+                "comments": [ ],
+                "posts": [ ],
+                "userGroups": [ ]
+            }
+        },
+        {
+            "id": "406",
+            "firstName": "Ed",
+            "lastName": "Burns",
+            "links": {
+                "comments": [ ],
+                "posts": [ ],
+                "userGroups": [ ]
+            }
+        },
+        {
+            "id": "405",
+            "firstName": "Michelle",
+            "lastName": "Johnson",
+            "links": {
+                "comments": [ ],
+                "posts": [ ],
+                "userGroups": [ ]
+            }
+        },
+        {
+            "id": "408",
+            "firstName": "Pat",
+            "lastName": "Morgan",
+            "links": {
+                "comments": [ ],
+                "posts": [ ],
+                "userGroups": [ ]
+            }
+        },
+        {
+            "id": "404",
+            "firstName": "Richard",
+            "lastName": "Smith",
+            "links": {
+                "comments": [ ],
+                "posts": [ ],
+                "userGroups": [ ]
+            }
+        },
+        {
+            "id": "410",
+            "firstName": "Sally",
+            "lastName": "Burns",
+            "links": {
+                "comments": [ ],
+                "posts": [ ],
+                "userGroups": [ ]
+            }
+        },
+        {
+            "id": "407",
+            "firstName": "Thomas",
+            "lastName": "Potter",
+            "links": {
+                "comments": [ ],
+                "posts": [ ],
+                "userGroups": [ ]
+            }
+        }
+    ]
+}

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Users_GetSortedByColumnMissingDirectionResponse.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Users_GetSortedByColumnMissingDirectionResponse.json
@@ -1,0 +1,12 @@
+﻿{
+    "errors": [
+        {
+            "id": "{{SOME_GUID}}",
+            "status": "500",
+            "title": "The sort expression \"firstName\" does not begin with a direction indicator (+ or -).",
+            "detail": null,
+            "inner": null,
+            "stackTrace":null
+        }
+    ]
+}

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Users_GetSortedByMixedDirectionResponse.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Users_GetSortedByMixedDirectionResponse.json
@@ -1,0 +1,104 @@
+﻿{
+    "users": [
+        {
+            "id": "410",
+            "firstName": "Sally",
+            "lastName":  "Burns",
+            "links": {
+                "comments": [ ],
+                "posts": [ ],
+                "userGroups": [ ]
+            }
+        },
+        {
+            "id": "406",
+            "firstName": "Ed",
+            "lastName":  "Burns",
+            "links": {
+                "comments": [ ],
+                "posts": [ ],
+                "userGroups": [ ]
+            }
+        },
+        {
+            "id": "409",
+            "firstName": "Charlie",
+            "lastName": "Burns",
+            "links": {
+                "comments": [ ],
+                "posts": [ ],
+                "userGroups": [ ]
+            }
+        },
+        {
+            "id": "405",
+            "firstName": "Michelle",
+            "lastName":  "Johnson",
+            "links": {
+                "comments": [ ],
+                "posts": [ ],
+                "userGroups": [ ]
+            }
+        },
+        {
+            "id": "402",
+            "firstName": "Bob",
+            "lastName":  "Jones",
+            "links": {
+                "comments": [ "102" ],
+                "posts": [ "204" ],
+                "userGroups": [ ]
+            }
+        },
+        {
+            "id": "403",
+            "firstName": "Charlie",
+            "lastName":  "Michaels",
+            "links": {
+                "comments": [ "101", "103", "104" ],
+                "posts": [ ],
+                "userGroups": [ ]
+            }
+        },
+        {
+            "id": "408",
+            "firstName": "Pat",
+            "lastName":  "Morgan",
+            "links": {
+                "comments": [ ],
+                "posts": [ ],
+                "userGroups": [ ]
+            }
+        },
+        {
+            "id": "407",
+            "firstName": "Thomas",
+            "lastName":  "Potter",
+            "links": {
+                "comments": [ ],
+                "posts": [ ],
+                "userGroups": [ ]
+            }
+        },
+        {
+            "id": "404",
+            "firstName": "Richard",
+            "lastName":  "Smith",
+            "links": {
+                "comments": [ ],
+                "posts": [ ],
+                "userGroups": [ ]
+            }
+        },
+        {
+            "id": "401",
+            "firstName": "Alice",
+            "lastName":  "Smith",
+            "links": {
+                "comments": [ "105" ],
+                "posts": [ "201", "202", "203" ],
+                "userGroups": [ ]
+            }
+        }
+    ]
+}

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Users_GetSortedByMultipleAscendingResponse.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Users_GetSortedByMultipleAscendingResponse.json
@@ -1,0 +1,104 @@
+﻿{
+    "users": [
+        {
+            "id": "409",
+            "firstName": "Charlie",
+            "lastName": "Burns",
+            "links": {
+                "comments": [ ],
+                "posts": [ ],
+                "userGroups": [ ]
+            }
+        },
+        {
+            "id": "406",
+            "firstName": "Ed",
+            "lastName":  "Burns",
+            "links": {
+                "comments": [ ],
+                "posts": [ ],
+                "userGroups": [ ]
+            }
+        },
+        {
+            "id": "410",
+            "firstName": "Sally",
+            "lastName":  "Burns",
+            "links": {
+                "comments": [ ],
+                "posts": [ ],
+                "userGroups": [ ]
+            }
+        },
+        {
+            "id": "405",
+            "firstName": "Michelle",
+            "lastName":  "Johnson",
+            "links": {
+                "comments": [ ],
+                "posts": [ ],
+                "userGroups": [ ]
+            }
+        },
+        {
+            "id": "402",
+            "firstName": "Bob",
+            "lastName":  "Jones",
+            "links": {
+                "comments": [ "102" ],
+                "posts": [ "204" ],
+                "userGroups": [ ]
+            }
+        },
+        {
+            "id": "403",
+            "firstName": "Charlie",
+            "lastName":  "Michaels",
+            "links": {
+                "comments": [ "101", "103", "104" ],
+                "posts": [ ],
+                "userGroups": [ ]
+            }
+        },
+        {
+            "id": "408",
+            "firstName": "Pat",
+            "lastName":  "Morgan",
+            "links": {
+                "comments": [ ],
+                "posts": [ ],
+                "userGroups": [ ]
+            }
+        },
+        {
+            "id": "407",
+            "firstName": "Thomas",
+            "lastName":  "Potter",
+            "links": {
+                "comments": [ ],
+                "posts": [ ],
+                "userGroups": [ ]
+            }
+        },
+        {
+            "id": "401",
+            "firstName": "Alice",
+            "lastName":  "Smith",
+            "links": {
+                "comments": [ "105" ],
+                "posts": [ "201", "202", "203" ],
+                "userGroups": [ ]
+            }
+        },
+        {
+            "id": "404",
+            "firstName": "Richard",
+            "lastName":  "Smith",
+            "links": {
+                "comments": [ ],
+                "posts": [ ],
+                "userGroups": [ ]
+            }
+        }
+    ]
+}

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Users_GetSortedByMultipleDescendingResponse.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Users_GetSortedByMultipleDescendingResponse.json
@@ -1,0 +1,104 @@
+﻿{
+    "users": [
+        {
+            "id": "404",
+            "firstName": "Richard",
+            "lastName":  "Smith",
+            "links": {
+                "comments": [ ],
+                "posts": [ ],
+                "userGroups": [ ]
+            }
+        },
+        {
+            "id": "401",
+            "firstName": "Alice",
+            "lastName": "Smith",
+            "links": {
+                "comments": [ "105" ],
+                "posts": [ "201", "202", "203" ],
+                "userGroups": [ ]
+            }
+        },
+        {
+            "id": "407",
+            "firstName": "Thomas",
+            "lastName": "Potter",
+            "links": {
+                "comments": [ ],
+                "posts": [ ],
+                "userGroups": [ ]
+            }
+        },
+        {
+            "id": "408",
+            "firstName": "Pat",
+            "lastName": "Morgan",
+            "links": {
+                "comments": [ ],
+                "posts": [ ],
+                "userGroups": [ ]
+            }
+        },
+        {
+            "id": "403",
+            "firstName": "Charlie",
+            "lastName": "Michaels",
+            "links": {
+                "comments": [ "101", "103", "104" ],
+                "posts": [ ],
+                "userGroups": [ ]
+            }
+        },
+        {
+            "id": "402",
+            "firstName": "Bob",
+            "lastName": "Jones",
+            "links": {
+                "comments": [ "102" ],
+                "posts": [ "204" ],
+                "userGroups": [ ]
+            }
+        },
+        {
+            "id": "405",
+            "firstName": "Michelle",
+            "lastName": "Johnson",
+            "links": {
+                "comments": [ ],
+                "posts": [ ],
+                "userGroups": [ ]
+            }
+        },
+        {
+            "id": "410",
+            "firstName": "Sally",
+            "lastName": "Burns",
+            "links": {
+                "comments": [ ],
+                "posts": [ ],
+                "userGroups": [ ]
+            }
+        },
+        {
+            "id": "406",
+            "firstName": "Ed",
+            "lastName": "Burns",
+            "links": {
+                "comments": [ ],
+                "posts": [ ],
+                "userGroups": [ ]
+            }
+        },
+        {
+            "id": "409",
+            "firstName": "Charlie",
+            "lastName": "Burns",
+            "links": {
+                "comments": [ ],
+                "posts": [ ],
+                "userGroups": [ ]
+            }
+        }
+    ]
+}

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Users_GetSortedBySameColumnTwiceResponse.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Users_GetSortedBySameColumnTwiceResponse.json
@@ -1,0 +1,12 @@
+﻿{
+    "errors": [
+        {
+            "id": "{{SOME_GUID}}",
+            "status": "500",
+            "title": "The attribute \"firstName\" was specified more than once.",
+            "detail": null,
+            "inner": null,
+            "stackTrace":null
+        }
+    ]
+}

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Users_GetSortedByUnknownColumnResponse.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Users_GetSortedByUnknownColumnResponse.json
@@ -1,0 +1,12 @@
+﻿{
+    "errors": [
+        {
+            "id": "{{SOME_GUID}}",
+            "status": "500",
+            "title": "The attribute \"foobar\" does not exist on type \"users\".",
+            "detail": null,
+            "inner": null,
+            "stackTrace":null
+        }
+    ]
+}

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Users_GetSortedDescendingResponse.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Users_GetSortedDescendingResponse.json
@@ -1,0 +1,104 @@
+﻿{
+    "users": [
+        {
+            "id": "407",
+            "firstName": "Thomas",
+            "lastName":  "Potter",
+            "links": {
+                "comments": [ ],
+                "posts": [ ],
+                "userGroups": [ ]
+            }
+        },
+        {
+            "id": "410",
+            "firstName": "Sally",
+            "lastName":  "Burns",
+            "links": {
+                "comments": [ ],
+                "posts": [ ],
+                "userGroups": [ ]
+            }
+        },
+        {
+            "id": "404",
+            "firstName": "Richard",
+            "lastName":  "Smith",
+            "links": {
+                "comments": [ ],
+                "posts": [ ],
+                "userGroups": [ ]
+            }
+        },
+        {
+            "id": "408",
+            "firstName": "Pat",
+            "lastName":  "Morgan",
+            "links": {
+                "comments": [ ],
+                "posts": [ ],
+                "userGroups": [ ]
+            }
+        },
+        {
+            "id": "405",
+            "firstName": "Michelle",
+            "lastName":  "Johnson",
+            "links": {
+                "comments": [ ],
+                "posts": [ ],
+                "userGroups": [ ]
+            }
+        },
+        {
+            "id": "406",
+            "firstName": "Ed",
+            "lastName":  "Burns",
+            "links": {
+                "comments": [ ],
+                "posts": [ ],
+                "userGroups": [ ]
+            }
+        },
+        {
+            "id": "403",
+            "firstName": "Charlie",
+            "lastName": "Michaels",
+            "links": {
+                "comments": [ "101", "103", "104" ],
+                "posts": [ ],
+                "userGroups": [ ]
+            }
+        },
+        {
+            "id": "409",
+            "firstName": "Charlie",
+            "lastName":  "Burns",
+            "links": {
+                "comments": [ ],
+                "posts": [ ],
+                "userGroups": [ ]
+            }
+        },
+        {
+            "id": "402",
+            "firstName": "Bob",
+            "lastName":  "Jones",
+            "links": {
+                "comments": [ "102" ],
+                "posts": [ "204" ],
+                "userGroups": [ ]
+            }
+        },
+        {
+            "id": "401",
+            "firstName": "Alice",
+            "lastName":  "Smith",
+            "links": {
+                "comments": [ "105" ],
+                "posts": [ "201", "202", "203" ],
+                "userGroups": [ ]
+            }
+        }
+    ]
+}

--- a/JSONAPI.EntityFramework.Tests/Acceptance/UserGroupsTests.cs
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/UserGroupsTests.cs
@@ -12,7 +12,7 @@ namespace JSONAPI.EntityFramework.Tests.Acceptance
         {
             using (var effortConnection = GetEffortConnection())
             {
-                await TestGet(effortConnection, "user-groups", @"Acceptance\Fixtures\UserGroups_GetResponse.json");
+                await ExpectGetToSucceed(effortConnection, "user-groups", @"Acceptance\Fixtures\UserGroups_GetResponse.json");
             }
         }
     }

--- a/JSONAPI.EntityFramework.Tests/JSONAPI.EntityFramework.Tests.csproj
+++ b/JSONAPI.EntityFramework.Tests/JSONAPI.EntityFramework.Tests.csproj
@@ -38,7 +38,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Effort">
+    <Reference Include="Effort, Version=1.0.0.0, Culture=neutral, PublicKeyToken=6a46696d54971e6d, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Effort.EF6.1.1.4\lib\net45\Effort.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
@@ -75,7 +76,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NMemory">
+    <Reference Include="NMemory, Version=1.0.0.0, Culture=neutral, PublicKeyToken=6a46696d54971e6d, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\NMemory.1.0.1\lib\net45\NMemory.dll</HintPath>
     </Reference>
     <Reference Include="Owin">
@@ -111,6 +113,7 @@
     <Compile Include="Acceptance\UserGroupsTests.cs" />
     <Compile Include="Acceptance\PostsTests.cs" />
     <Compile Include="Acceptance\AcceptanceTestsBase.cs" />
+    <Compile Include="Acceptance\SortingTests.cs" />
     <Compile Include="ActionFilters\EnumerateQueryableAsyncAttributeTests.cs" />
     <Compile Include="EntityConverterTests.cs" />
     <Compile Include="EntityFrameworkMaterializerTests.cs" />
@@ -128,9 +131,14 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Acceptance\Fixtures\UserGroups_GetResponse.json" />
-    <None Include="Acceptance\Data\UserGroup.csv">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
+    <EmbeddedResource Include="Acceptance\Fixtures\Users_GetSortedAscendingResponse.json" />
+    <EmbeddedResource Include="Acceptance\Fixtures\Users_GetSortedDescendingResponse.json" />
+    <EmbeddedResource Include="Acceptance\Fixtures\Users_GetSortedByMultipleAscendingResponse.json" />
+    <EmbeddedResource Include="Acceptance\Fixtures\Users_GetSortedByMultipleDescendingResponse.json" />
+    <EmbeddedResource Include="Acceptance\Fixtures\Users_GetSortedByMixedDirectionResponse.json" />
+    <EmbeddedResource Include="Acceptance\Fixtures\Users_GetSortedByUnknownColumnResponse.json" />
+    <EmbeddedResource Include="Acceptance\Fixtures\Users_GetSortedBySameColumnTwiceResponse.json" />
+    <EmbeddedResource Include="Acceptance\Fixtures\Users_GetSortedByColumnMissingDirectionResponse.json" />
     <None Include="App.Config">
       <SubType>Designer</SubType>
     </None>
@@ -154,6 +162,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="Acceptance\Data\Post.csv">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="Acceptance\Data\UserGroup.csv">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <EmbeddedResource Include="Data\Comment.json">

--- a/JSONAPI.Tests/ActionFilters/EnableSortingAttributeTests.cs
+++ b/JSONAPI.Tests/ActionFilters/EnableSortingAttributeTests.cs
@@ -1,0 +1,181 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Web.Http;
+using System.Web.Http.Controllers;
+using System.Web.Http.Filters;
+using FluentAssertions;
+using JSONAPI.ActionFilters;
+using JSONAPI.Core;
+using JSONAPI.Json;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace JSONAPI.Tests.ActionFilters
+{
+    [TestClass]
+    public class EnableSortingAttributeTests
+    {
+        private class Dummy
+        {
+            public string Id { get; set; }
+
+            public string FirstName { get; set; }
+
+            public string LastName { get; set; }
+        }
+
+        private IList<Dummy> _fixtures;
+        private IQueryable<Dummy> _fixturesQuery;
+
+        [TestInitialize]
+        public void SetupFixtures()
+        {
+            _fixtures = new List<Dummy>
+            {
+                new Dummy { Id = "1", FirstName = "Thomas", LastName = "Paine" },
+                new Dummy { Id = "2", FirstName = "Samuel", LastName = "Adams" },
+                new Dummy { Id = "3", FirstName = "George", LastName = "Washington"},
+                new Dummy { Id = "4", FirstName = "Thomas", LastName = "Jefferson" },
+                new Dummy { Id = "5", FirstName = "Martha", LastName = "Washington"},
+                new Dummy { Id = "6", FirstName = "Abraham", LastName = "Lincoln" },
+                new Dummy { Id = "7", FirstName = "Andrew", LastName = "Jackson" },
+                new Dummy { Id = "8", FirstName = "Andrew", LastName = "Johnson" },
+                new Dummy { Id = "8", FirstName = "William", LastName = "Harrison" }
+            };
+            _fixturesQuery = _fixtures.AsQueryable();
+        }
+
+        private HttpActionExecutedContext CreateActionExecutedContext(IModelManager modelManager, string uri)
+        {
+            var formatter = new JsonApiFormatter(modelManager);
+
+            var httpContent = new ObjectContent(typeof (IQueryable<Dummy>), _fixturesQuery, formatter);
+
+            return new HttpActionExecutedContext
+            {
+                ActionContext = new HttpActionContext
+                {
+                    ControllerContext = new HttpControllerContext
+                    {
+                        Request = new HttpRequestMessage(HttpMethod.Get, new Uri(uri))
+                    }
+                },
+                Response = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = httpContent
+                }
+            };
+        }
+
+        private HttpResponseMessage GetActionFilterResponse(string uri)
+        {
+            var modelManager = new ModelManager(new PluralizationService(new Dictionary<string, string>
+            {
+                { "Dummy", "Dummies" }
+            }));
+
+            var filter = new EnableSortingAttribute(modelManager);
+
+            var context = CreateActionExecutedContext(modelManager, uri);
+
+            filter.OnActionExecuted(context);
+
+            return context.Response;
+        }
+
+        private T[] GetArray<T>(string uri)
+        {
+            var response = GetActionFilterResponse(uri);
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            var returnedContent = (ObjectContent)response.Content;
+            var returnedQueryable = (IQueryable<T>)returnedContent.Value;
+            return returnedQueryable.ToArray();
+        }
+
+        private void Expect400(string uri, string expectedMessage)
+        {
+            Action action = () =>
+            {
+                GetActionFilterResponse(uri);
+            };
+            var response = action.ShouldThrow<HttpResponseException>().Which.Response;
+
+            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            var value = (HttpError)((ObjectContent<HttpError>)response.Content).Value;
+            value.Message.Should().Be(expectedMessage);
+        }
+
+        [TestMethod]
+        public void Sorts_by_attribute_ascending()
+        {
+            var array = GetArray<Dummy>("http://api.example.com/dummies?sort=%2BfirstName");
+            array.Should().BeInAscendingOrder(d => d.FirstName);
+        }
+
+        [TestMethod]
+        public void Sorts_by_attribute_descending()
+        {
+            var array = GetArray<Dummy>("http://api.example.com/dummies?sort=-firstName");
+            array.Should().BeInDescendingOrder(d => d.FirstName);
+        }
+
+        [TestMethod]
+        public void Sorts_by_two_ascending_attributes()
+        {
+            var array = GetArray<Dummy>("http://api.example.com/dummies?sort=%2BlastName,%2BfirstName");
+            array.Should().ContainInOrder(_fixtures.OrderBy(d => d.LastName + d.FirstName));
+        }
+
+        [TestMethod]
+        public void Sorts_by_two_descending_attributes()
+        {
+            var array = GetArray<Dummy>("http://api.example.com/dummies?sort=-lastName,-firstName");
+            array.Should().ContainInOrder(_fixtures.OrderByDescending(d => d.LastName + d.FirstName));
+        }
+
+        [TestMethod]
+        public void Returns_400_if_sort_argument_is_empty()
+        {
+            Expect400("http://api.example.com/dummies?sort=", "The sort expression \"\" is invalid.");
+        }
+
+        [TestMethod]
+        public void Returns_400_if_sort_argument_is_whitespace()
+        {
+            Expect400("http://api.example.com/dummies?sort= ", "The sort expression \"\" is invalid.");
+        }
+
+        [TestMethod]
+        public void Returns_400_if_property_name_is_missing()
+        {
+            Expect400("http://api.example.com/dummies?sort=%2B", "The property name is missing.");
+        }
+
+        [TestMethod]
+        public void Returns_400_if_property_name_is_whitespace()
+        {
+            Expect400("http://api.example.com/dummies?sort=%2B ", "The property name is missing.");
+        }
+
+        [TestMethod]
+        public void Returns_400_if_no_property_exists()
+        {
+            Expect400("http://api.example.com/dummies?sort=%2Bfoobar", "The attribute \"foobar\" does not exist on type \"dummies\".");
+        }
+
+        [TestMethod]
+        public void Returns_400_if_the_same_property_is_specified_more_than_once()
+        {
+            Expect400("http://api.example.com/dummies?sort=%2BlastName,%2BlastName", "The attribute \"lastName\" was specified more than once.");
+        }
+
+        [TestMethod]
+        public void Returns_400_if_sort_argument_doesnt_start_with_plus_or_minus()
+        {
+            Expect400("http://api.example.com/dummies?sort=lastName", "The sort expression \"lastName\" does not begin with a direction indicator (+ or -).");
+        }
+    }
+}

--- a/JSONAPI.Tests/JSONAPI.Tests.csproj
+++ b/JSONAPI.Tests/JSONAPI.Tests.csproj
@@ -79,6 +79,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ActionFilters\EnableSortingAttributeTests.cs" />
     <Compile Include="ActionFilters\EnableFilteringAttributeTests.cs" />
     <Compile Include="Core\MetadataManagerTests.cs" />
     <Compile Include="Core\ModelManagerTests.cs" />

--- a/JSONAPI.TodoMVC.API/Startup.cs
+++ b/JSONAPI.TodoMVC.API/Startup.cs
@@ -31,6 +31,7 @@ namespace JSONAPI.TodoMVC.API
 
             // Global filters
             config.Filters.Add(new EnumerateQueryableAsyncAttribute());
+            config.Filters.Add(new EnableSortingAttribute(modelManager));
             config.Filters.Add(new EnableFilteringAttribute(modelManager));
 
             // Override controller selector

--- a/JSONAPI/ActionFilters/EnableSortingAttribute.cs
+++ b/JSONAPI/ActionFilters/EnableSortingAttribute.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Web.Http;
+using System.Web.Http.Filters;
+using JSONAPI.Core;
+
+namespace JSONAPI.ActionFilters
+{
+    /// <summary>
+    /// Sorts the IQueryable response content according to json-api
+    /// </summary>
+    public class EnableSortingAttribute : ActionFilterAttribute
+    {
+        private const string SortQueryParamKey = "sort";
+
+        private readonly IModelManager _modelManager;
+
+        /// <param name="modelManager">The model manager to use to look up model properties by json key name</param>
+        public EnableSortingAttribute(IModelManager modelManager)
+        {
+            _modelManager = modelManager;
+        }
+
+        private readonly Lazy<MethodInfo> _openMakeOrderedQueryMethod =
+            new Lazy<MethodInfo>(() => typeof(EnableSortingAttribute).GetMethod("MakeOrderedQuery", BindingFlags.NonPublic | BindingFlags.Instance));
+
+        public override void OnActionExecuted(HttpActionExecutedContext actionExecutedContext)
+        {
+            if (actionExecutedContext.Response != null)
+            {
+                var objectContent = actionExecutedContext.Response.Content as ObjectContent;
+                if (objectContent == null) return;
+
+                var objectType = objectContent.ObjectType;
+                if (!objectType.IsGenericType || objectType.GetGenericTypeDefinition() != typeof (IQueryable<>)) return;
+
+                var queryParams = actionExecutedContext.Request.GetQueryNameValuePairs();
+                var sortParam = queryParams.FirstOrDefault(kvp => kvp.Key == SortQueryParamKey);
+                if (sortParam.Key != SortQueryParamKey) return;
+
+                var queryableElementType = objectType.GenericTypeArguments[0];
+                var makeOrderedQueryMethod = _openMakeOrderedQueryMethod.Value.MakeGenericMethod(queryableElementType);
+
+                try
+                {
+                    var orderedQuery = makeOrderedQueryMethod.Invoke(this, new[] {objectContent.Value, sortParam.Value});
+
+                    actionExecutedContext.Response.Content = new ObjectContent(objectType, orderedQuery,
+                        objectContent.Formatter);
+                }
+                catch (TargetInvocationException ex)
+                {
+                    var statusCode = ex.InnerException is SortingException
+                        ? HttpStatusCode.BadRequest
+                        : HttpStatusCode.InternalServerError;
+                    throw new HttpResponseException(
+                        actionExecutedContext.Request.CreateErrorResponse(statusCode, ex.InnerException.Message));
+                }
+            }
+        }
+
+        // ReSharper disable once UnusedMember.Local
+        private IQueryable<T> MakeOrderedQuery<T>(IQueryable<T> sourceQuery, string sortParam)
+        {
+            var selectors = new List<Tuple<bool, Expression<Func<T, object>>>>();
+
+            var usedProperties = new Dictionary<PropertyInfo, object>();
+
+            var sortExpressions = sortParam.Split(',');
+            foreach (var sortExpression in sortExpressions)
+            {
+                if (string.IsNullOrWhiteSpace(sortExpression))
+                    throw new SortingException(string.Format("The sort expression \"{0}\" is invalid.", sortExpression));
+
+                var ascending = sortExpression[0] == '+';
+                var descending = sortExpression[0] == '-';
+                if (!ascending && !descending)
+                    throw new SortingException(string.Format("The sort expression \"{0}\" does not begin with a direction indicator (+ or -).", sortExpression));
+
+                var propertyName = sortExpression.Substring(1);
+                if (string.IsNullOrWhiteSpace(propertyName))
+                    throw new SortingException("The property name is missing.");
+
+                var property = _modelManager.GetPropertyForJsonKey(typeof(T), propertyName);
+
+                if (property == null)
+                    throw new SortingException(string.Format("The attribute \"{0}\" does not exist on type \"{1}\".",
+                        propertyName, _modelManager.GetJsonKeyForType(typeof (T))));
+                
+                if (usedProperties.ContainsKey(property))
+                    throw new SortingException(string.Format("The attribute \"{0}\" was specified more than once.", propertyName));
+
+                usedProperties[property] = null;
+
+                var paramExpr = Expression.Parameter(typeof (T));
+                var propertyExpr = Expression.Property(paramExpr, property);
+                var selector = Expression.Lambda<Func<T, object>>(propertyExpr, paramExpr);
+
+                selectors.Add(Tuple.Create(ascending, selector));
+            }
+
+            var firstSelector = selectors.First();
+
+            IOrderedQueryable<T> workingQuery =
+                firstSelector.Item1
+                    ? sourceQuery.OrderBy(firstSelector.Item2)
+                    : sourceQuery.OrderByDescending(firstSelector.Item2);
+
+            return selectors.Skip(1).Aggregate(workingQuery,
+                (current, selector) =>
+                    selector.Item1 ? current.ThenBy(selector.Item2) : current.ThenByDescending(selector.Item2));
+        }
+    }
+
+    internal class SortingException : Exception
+    {
+        public SortingException(string message)
+            : base(message)
+        {
+            
+        }
+    }
+}

--- a/JSONAPI/JSONAPI.csproj
+++ b/JSONAPI/JSONAPI.csproj
@@ -67,6 +67,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ActionFilters\EnableFilteringAttribute.cs" />
+    <Compile Include="ActionFilters\EnableSortingAttribute.cs" />
     <Compile Include="Attributes\IncludeInPayload.cs" />
     <Compile Include="Attributes\LinkTemplate.cs" />
     <Compile Include="Attributes\SerializeAs.cs" />


### PR DESCRIPTION
I implemented sorting as another action filter. Its OnActionExecuted needs to run after the filtering attribute (so it has to be placed before it in the config, due to nesting). This works according to the [new spec](https://github.com/dgeb/json-api/blob/v1rc2/format/index.md#sorting-), so it requires sort expressions to be prefixed with + or -.

Closes #17 