### PR TITLE
ensure that inner exceptions are given an ID

### DIFF
--- a/JSONAPI.Tests/Data/ErrorSerializerTest.json
+++ b/JSONAPI.Tests/Data/ErrorSerializerTest.json
@@ -1,12 +1,19 @@
 {
     "errors": [
         {
-            "id": "TEST-ERROR-ID",
+            "id": "OUTER-ID",
             "status": "500",
             "title": "System.Exception",
-            "detail": "This is the exception message!",
-            "inner": null,
-            "stackTrace": "Stack trace would go here"
+            "detail": "Outer exception message",
+            "stackTrace": "Outer stack trace",
+            "inner": { 
+                "id": "INNER-ID",
+                "status": "500",
+                "title": "Castle.Proxies.ExceptionProxy",
+                "detail": "Inner exception message",
+                "stackTrace": "Inner stack trace",
+                "inner": null
+            }
         }
     ]
 }

--- a/JSONAPI.Tests/JSONAPI.Tests.csproj
+++ b/JSONAPI.Tests/JSONAPI.Tests.csproj
@@ -45,6 +45,10 @@
       <HintPath>..\packages\FluentAssertions.3.2.2\lib\net45\FluentAssertions.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Moq, Version=4.2.1502.911, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Moq.4.2.1502.0911\lib\net40\Moq.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/JSONAPI.Tests/packages.config
+++ b/JSONAPI.Tests/packages.config
@@ -4,5 +4,6 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.2" targetFramework="net45" />
+  <package id="Moq" version="4.2.1502.0911" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
 </packages>

--- a/JSONAPI/Properties/AssemblyInfo.cs
+++ b/JSONAPI/Properties/AssemblyInfo.cs
@@ -25,6 +25,10 @@ using System.Runtime.InteropServices;
 [assembly: InternalsVisibleTo("JSONAPI.Tests")]
 [assembly: InternalsVisibleTo("JSONAPI.EntityFramework.Tests")]
 
+// This assembly is the default dynamic assembly generated Castle DynamicProxy, 
+// used by Moq. Paste in a single line.   
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
+
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version


### PR DESCRIPTION
Closes #63 

This doesn't leave us any better off in terms of being able to log errors along with their ID, but at least now the inner exceptions will have an ID too... 