### PR TITLE
ensure correct content-type is sent

### DIFF
--- a/JSONAPI.EntityFramework.Tests/Acceptance/AcceptanceTestsBase.cs
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/AcceptanceTestsBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Data.Common;
+using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -26,7 +27,7 @@ namespace JSONAPI.EntityFramework.Tests.Acceptance
             return TestHelpers.GetEffortConnection(@"Acceptance\Data");
         }
 
-        protected async Task AssertResponseContent(HttpResponseMessage response, string expectedResponseTextResourcePath)
+        protected static async Task AssertResponseContent(HttpResponseMessage response, string expectedResponseTextResourcePath)
         {
             var responseContent = await response.Content.ReadAsStringAsync();
 
@@ -36,6 +37,8 @@ namespace JSONAPI.EntityFramework.Tests.Acceptance
             redactedResponse = StackTraceRegex.Replace(redactedResponse, "\"stackTrace\":\"{{STACK_TRACE}}\"");
 
             redactedResponse.Should().Be(expectedResponse);
+            response.Content.Headers.ContentType.MediaType.Should().Be("application/vnd.api+json");
+            response.Content.Headers.ContentType.CharSet.Should().Be("utf-8");
         }
 
         #region GET


### PR DESCRIPTION
This PR ensures that:

* The Content-Type for responses is set to `application/vnd.api+json` by default.
* 400 errors set `application/vnd.api+json` instead of `text/html`.