### PR TITLE
inject IMetadataManager onto EntityFrameworkMaterializer

### DIFF
--- a/JSONAPI.EntityFramework.Tests.TestWebApp/Controllers/CommentsController.cs
+++ b/JSONAPI.EntityFramework.Tests.TestWebApp/Controllers/CommentsController.cs
@@ -15,7 +15,7 @@ namespace JSONAPI.EntityFramework.Tests.TestWebApp.Controllers
 
         protected override IMaterializer MaterializerFactory()
         {
-            return new EntityFrameworkMaterializer(DbContext);
+            return new EntityFrameworkMaterializer(DbContext, MetadataManager.Instance);
         }
     }
 }

--- a/JSONAPI.EntityFramework.Tests.TestWebApp/Controllers/PostsController.cs
+++ b/JSONAPI.EntityFramework.Tests.TestWebApp/Controllers/PostsController.cs
@@ -15,7 +15,7 @@ namespace JSONAPI.EntityFramework.Tests.TestWebApp.Controllers
 
         protected override IMaterializer MaterializerFactory()
         {
-            return new EntityFrameworkMaterializer(DbContext);
+            return new EntityFrameworkMaterializer(DbContext, MetadataManager.Instance);
         }
     }
 }

--- a/JSONAPI.EntityFramework.Tests.TestWebApp/Controllers/TagsController.cs
+++ b/JSONAPI.EntityFramework.Tests.TestWebApp/Controllers/TagsController.cs
@@ -15,7 +15,7 @@ namespace JSONAPI.EntityFramework.Tests.TestWebApp.Controllers
 
         protected override IMaterializer MaterializerFactory()
         {
-            return new EntityFrameworkMaterializer(DbContext);
+            return new EntityFrameworkMaterializer(DbContext, MetadataManager.Instance);
         }
     }
 }

--- a/JSONAPI.EntityFramework.Tests.TestWebApp/Controllers/UserGroupsController.cs
+++ b/JSONAPI.EntityFramework.Tests.TestWebApp/Controllers/UserGroupsController.cs
@@ -15,7 +15,7 @@ namespace JSONAPI.EntityFramework.Tests.TestWebApp.Controllers
 
         protected override IMaterializer MaterializerFactory()
         {
-            return new EntityFrameworkMaterializer(DbContext);
+            return new EntityFrameworkMaterializer(DbContext, MetadataManager.Instance);
         }
     }
 }

--- a/JSONAPI.EntityFramework.Tests.TestWebApp/Controllers/UsersController.cs
+++ b/JSONAPI.EntityFramework.Tests.TestWebApp/Controllers/UsersController.cs
@@ -15,7 +15,7 @@ namespace JSONAPI.EntityFramework.Tests.TestWebApp.Controllers
 
         protected override IMaterializer MaterializerFactory()
         {
-            return new EntityFrameworkMaterializer(DbContext);
+            return new EntityFrameworkMaterializer(DbContext, MetadataManager.Instance);
         }
     }
 }

--- a/JSONAPI.EntityFramework.Tests/EntityConverterTests.cs
+++ b/JSONAPI.EntityFramework.Tests/EntityConverterTests.cs
@@ -126,7 +126,7 @@ namespace JSONAPI.EntityFramework.Tests
             JsonApiFormatter formatter = new JSONAPI.Json.JsonApiFormatter(new JSONAPI.Core.PluralizationService());
             MemoryStream stream = new MemoryStream();
 
-            EntityFrameworkMaterializer materializer = new EntityFrameworkMaterializer(context);
+            EntityFrameworkMaterializer materializer = new EntityFrameworkMaterializer(context, MetadataManager.Instance);
 
             string underpost = @"{""posts"":{""id"":""" + p.Id.ToString() + @""",""title"":""Not at all linkbait!""}}";
             stream = new MemoryStream(System.Text.Encoding.ASCII.GetBytes(underpost));

--- a/JSONAPI.EntityFramework.Tests/EntityFrameworkMaterializerTests.cs
+++ b/JSONAPI.EntityFramework.Tests/EntityFrameworkMaterializerTests.cs
@@ -5,6 +5,8 @@ using JSONAPI.EntityFramework.Tests.Models;
 using FluentAssertions;
 using System.Collections.Generic;
 using System.Data.Entity;
+using JSONAPI.Core;
+using Moq;
 
 namespace JSONAPI.EntityFramework.Tests
 {
@@ -54,7 +56,8 @@ namespace JSONAPI.EntityFramework.Tests
         public void GetKeyNamesStandardIdTest()
         {
             // Arrange
-            var materializer = new EntityFrameworkMaterializer(context);
+            var mockMetadataManager = new Mock<IMetadataManager>(MockBehavior.Strict);
+            var materializer = new EntityFrameworkMaterializer(context, mockMetadataManager.Object);
 
             // Act
             IEnumerable<string> keyNames = materializer.GetKeyNames(typeof(Post));
@@ -68,7 +71,8 @@ namespace JSONAPI.EntityFramework.Tests
         public void GetKeyNamesNonStandardIdTest()
         {
             // Arrange
-            var materializer = new EntityFrameworkMaterializer(context);
+            var mockMetadataManager = new Mock<IMetadataManager>(MockBehavior.Strict);
+            var materializer = new EntityFrameworkMaterializer(context, mockMetadataManager.Object);
 
             // Act
             IEnumerable<string> keyNames = materializer.GetKeyNames(typeof(Backlink));
@@ -82,7 +86,8 @@ namespace JSONAPI.EntityFramework.Tests
         public void GetKeyNamesNotAnEntityTest()
         {
             // Arrange
-            var materializer = new EntityFrameworkMaterializer(context);
+            var mockMetadataManager = new Mock<IMetadataManager>(MockBehavior.Strict);
+            var materializer = new EntityFrameworkMaterializer(context, mockMetadataManager.Object);
 
             // Act
             Action action = () =>

--- a/JSONAPI.EntityFramework/EntityFrameworkMaterializer.cs
+++ b/JSONAPI.EntityFramework/EntityFrameworkMaterializer.cs
@@ -17,6 +17,8 @@ namespace JSONAPI.EntityFramework
     /// </summary>
     public partial class EntityFrameworkMaterializer : IMaterializer
     {
+        private readonly IMetadataManager _metadataManager;
+
         /// <summary>
         /// The DbContext instance used to perform materializer operations
         /// </summary>
@@ -26,8 +28,9 @@ namespace JSONAPI.EntityFramework
         /// Creates a new EntityFrameworkMaterializer.
         /// </summary>
         /// <param name="context">The DbContext instance used to perform materializer operations</param>
-        public EntityFrameworkMaterializer(DbContext context)
+        public EntityFrameworkMaterializer(DbContext context, IMetadataManager metadataManager)
         {
+            _metadataManager = metadataManager;
             DbContext = context;
         }
 
@@ -308,7 +311,7 @@ namespace JSONAPI.EntityFramework
             foreach (PropertyInfo prop in props)
             {
                 // Comply with the spec, if a key was not set, it should not be updated!
-                if (!MetadataManager.Instance.PropertyWasPresent(ephemeral, prop)) continue;
+                if (!_metadataManager.PropertyWasPresent(ephemeral, prop)) continue;
 
                 if (IsMany(prop.PropertyType))
                 {

--- a/JSONAPI.EntityFramework/Http/ApiController.cs
+++ b/JSONAPI.EntityFramework/Http/ApiController.cs
@@ -4,6 +4,7 @@ using System.Data.Entity;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using JSONAPI.Core;
 
 namespace JSONAPI.EntityFramework.Http
 {
@@ -18,7 +19,8 @@ namespace JSONAPI.EntityFramework.Http
             if (_materializer == null)
             {
                 DbContext context = (DbContext)Activator.CreateInstance(typeof(TC));
-                _materializer = new JSONAPI.EntityFramework.EntityFrameworkMaterializer(context);
+                var metadataManager = MetadataManager.Instance;
+                _materializer = new JSONAPI.EntityFramework.EntityFrameworkMaterializer(context, metadataManager);
             }
             return _materializer;
         }

--- a/JSONAPI/Core/IMetadataManager.cs
+++ b/JSONAPI/Core/IMetadataManager.cs
@@ -1,0 +1,20 @@
+﻿using System.Reflection;
+
+namespace JSONAPI.Core
+{
+    /// <summary>
+    /// Manages request-specific metadata
+    /// </summary>
+    public interface IMetadataManager
+    {
+        /// <summary>
+        /// Find whether or not a given property was
+        /// posted in the original JSON--i.e. to determine whether an update operation should be
+        /// performed, and/or if a default value should be used.
+        /// </summary>
+        /// <param name="deserialized">The object deserialized by JsonApiFormatter</param>
+        /// <param name="prop">The property to check</param>
+        /// <returns>Whether or not the property was found in the original JSON and set by the deserializer</returns>
+        bool PropertyWasPresent(object deserialized, PropertyInfo prop);
+    }
+}

--- a/JSONAPI/Core/MetadataManager.cs
+++ b/JSONAPI/Core/MetadataManager.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace JSONAPI.Core
 {
-    public sealed class MetadataManager
+    public sealed class MetadataManager : IMetadataManager
     {
         #region Singleton pattern
 
@@ -64,14 +64,7 @@ namespace JSONAPI.Core
             }
         }
 
-        /// <summary>
-        /// Find whether or not a given property was
-        /// posted in the original JSON--i.e. to determine whether an update operation should be
-        /// performed, and/or if a default value should be used.
-        /// </summary>
-        /// <param name="deserialized">The object deserialized by JsonApiFormatter</param>
-        /// <param name="prop">The property to check</param>
-        /// <returns>Whether or not the property was found in the original JSON and set by the deserializer</returns>
+        /// <inheritdoc />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool PropertyWasPresent(object deserialized, PropertyInfo prop)
         {

--- a/JSONAPI/JSONAPI.csproj
+++ b/JSONAPI/JSONAPI.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Attributes\SerializeAs.cs" />
     <Compile Include="Attributes\SerializeStringAsRawJsonAttribute.cs" />
     <Compile Include="Attributes\UseAsIdAttribute.cs" />
+    <Compile Include="Core\IMetadataManager.cs" />
     <Compile Include="Core\IModelManager.cs" />
     <Compile Include="Core\IPluralizationService.cs" />
     <Compile Include="Core\IMaterializer.cs" />


### PR DESCRIPTION
This PR makes `MetadataManager` implement an `IMetadataManager` interface. `EntityFrameworkMaterializer` now takes an `IMetadataManager` constructor parameter. This is the first step towards being able to de-singleton-ize `MetadataManager`.