### PR TITLE
Fixes EntityFrameworkMaterializer bugs when materializing Decimal, etc.

### DIFF
--- a/JSONAPI.EntityFramework/EntityFrameworkMaterializer.cs
+++ b/JSONAPI.EntityFramework/EntityFrameworkMaterializer.cs
@@ -10,6 +10,7 @@ using System.Data.Entity.Infrastructure;
 using System.Reflection;
 using System.Collections;
 using System.Data.Entity.Core;
+using JSONAPI.Extensions;
 
 namespace JSONAPI.EntityFramework
 {
@@ -163,15 +164,7 @@ namespace JSONAPI.EntityFramework
 
         public bool IsModel(Type objectType)
         {
-            if (objectType.IsPrimitive
-                || typeof(System.Guid).IsAssignableFrom(objectType)
-                || typeof(System.DateTime).IsAssignableFrom(objectType)
-                || typeof(System.DateTimeOffset).IsAssignableFrom(objectType)
-                || typeof(System.Guid?).IsAssignableFrom(objectType)
-                || typeof(System.DateTime?).IsAssignableFrom(objectType)
-                || typeof(System.DateTimeOffset?).IsAssignableFrom(objectType)
-                || typeof(String).IsAssignableFrom(objectType)
-                )
+            if (objectType.CanWriteAsJsonApiAttribute())
                 return false;
             else return true;
         }

--- a/JSONAPI/Extensions/TypeExtensions.cs
+++ b/JSONAPI/Extensions/TypeExtensions.cs
@@ -2,9 +2,9 @@
 
 namespace JSONAPI.Extensions
 {
-    internal static class TypeExtensions
+    public static class TypeExtensions
     {
-        internal static bool CanWriteAsJsonApiAttribute(this Type objectType)
+        public static bool CanWriteAsJsonApiAttribute(this Type objectType)
         {
             if (objectType.IsGenericType && objectType.GetGenericTypeDefinition() == typeof (Nullable<>))
                 objectType = objectType.GetGenericArguments()[0];


### PR DESCRIPTION
This cuts a duplicated method in EFM--but requires making the `TypeExtensions` public. Probably not a problem?

Didn't add any tests because arguably they'd just be duplicates of those on `CanWriteAsJsonApiAttribute`...should I anyway?