### PR TITLE
require registration of resource types

### DIFF
--- a/JSONAPI.EntityFramework.Tests.TestWebApp/Startup.cs
+++ b/JSONAPI.EntityFramework.Tests.TestWebApp/Startup.cs
@@ -66,6 +66,11 @@ namespace JSONAPI.EntityFramework.Tests.TestWebApp
 
             var pluralizationService = new PluralizationService();
             var modelManager = new ModelManager(pluralizationService);
+            modelManager.RegisterResourceType(typeof(Comment));
+            modelManager.RegisterResourceType(typeof(Post));
+            modelManager.RegisterResourceType(typeof(Tag));
+            modelManager.RegisterResourceType(typeof(User));
+            modelManager.RegisterResourceType(typeof(UserGroup));
 
             var formatter = new JsonApiFormatter(modelManager);
             config.Formatters.Clear();

--- a/JSONAPI.EntityFramework.Tests/EntityConverterTests.cs
+++ b/JSONAPI.EntityFramework.Tests/EntityConverterTests.cs
@@ -107,7 +107,10 @@ namespace JSONAPI.EntityFramework.Tests
         public void SerializeTest()
         {
             // Arrange
-            JsonApiFormatter formatter = new JSONAPI.Json.JsonApiFormatter(new JSONAPI.Core.PluralizationService());
+            var modelManager = new ModelManager(new Core.PluralizationService());
+            modelManager.RegisterResourceType(typeof(Post));
+
+            JsonApiFormatter formatter = new JSONAPI.Json.JsonApiFormatter(modelManager);
             MemoryStream stream = new MemoryStream();
 
             // Act
@@ -123,7 +126,10 @@ namespace JSONAPI.EntityFramework.Tests
         public async Task UnderpostingTest()
         {
             // Arrange
-            JsonApiFormatter formatter = new JSONAPI.Json.JsonApiFormatter(new JSONAPI.Core.PluralizationService());
+            var modelManager = new ModelManager(new Core.PluralizationService());
+            modelManager.RegisterResourceType(typeof(Post));
+
+            JsonApiFormatter formatter = new JSONAPI.Json.JsonApiFormatter(modelManager);
             MemoryStream stream = new MemoryStream();
 
             EntityFrameworkMaterializer materializer = new EntityFrameworkMaterializer(context, MetadataManager.Instance);

--- a/JSONAPI.Tests/ActionFilters/EnableSortingAttributeTests.cs
+++ b/JSONAPI.Tests/ActionFilters/EnableSortingAttributeTests.cs
@@ -75,6 +75,7 @@ namespace JSONAPI.Tests.ActionFilters
             {
                 { "Dummy", "Dummies" }
             }));
+            modelManager.RegisterResourceType(typeof(Dummy));
 
             var filter = new EnableSortingAttribute(modelManager);
 

--- a/JSONAPI.Tests/Core/MetadataManagerTests.cs
+++ b/JSONAPI.Tests/Core/MetadataManagerTests.cs
@@ -16,7 +16,9 @@ namespace JSONAPI.Tests.Core
             using (var inputStream = File.OpenRead("MetadataManagerPropertyWasPresentRequest.json"))
             {
                 // Arrange
-                JsonApiFormatter formatter = new JsonApiFormatter(new PluralizationService());
+                var modelManager = new ModelManager(new PluralizationService());
+                modelManager.RegisterResourceType(typeof(Post));
+                JsonApiFormatter formatter = new JsonApiFormatter(modelManager);
 
                 var p = (Post) formatter.ReadFromStreamAsync(typeof(Post), inputStream, null, null).Result;
 

--- a/JSONAPI.Tests/Core/ModelManagerTests.cs
+++ b/JSONAPI.Tests/Core/ModelManagerTests.cs
@@ -25,6 +25,11 @@ namespace JSONAPI.Tests.Core
             public string Data { get; set; }
         }
 
+        private class DerivedPost : Post
+        {
+            
+        }
+
         [TestMethod]
         public void FindsIdNamedId()
         {
@@ -88,6 +93,21 @@ namespace JSONAPI.Tests.Core
             Assert.AreEqual("comments", commentKey);
             Assert.AreEqual("comments", manyCommentKey);
             Assert.AreEqual("user-groups", userGroupsKey);
+        }
+
+        [TestMethod]
+        public void GetResourceTypeNameForType_gets_name_for_closest_registered_base_type_for_unregistered_type()
+        {
+            // Arrange
+            var pluralizationService = new PluralizationService();
+            var mm = new ModelManager(pluralizationService);
+            mm.RegisterResourceType(typeof(Post));
+
+            // Act
+            var resourceTypeName = mm.GetResourceTypeNameForType(typeof(DerivedPost));
+
+            // Assert
+            resourceTypeName.Should().Be("posts");
         }
 
         [TestMethod]

--- a/JSONAPI.Tests/Core/ModelManagerTests.cs
+++ b/JSONAPI.Tests/Core/ModelManagerTests.cs
@@ -5,6 +5,7 @@ using JSONAPI.Tests.Models;
 using System.Reflection;
 using System.Collections.Generic;
 using System.Collections;
+using FluentAssertions;
 
 namespace JSONAPI.Tests.Core
 {
@@ -64,18 +65,22 @@ namespace JSONAPI.Tests.Core
         }
 
         [TestMethod]
-        public void GetJsonKeyForTypeTest()
+        public void GetResourceTypeName_returns_correct_value_for_registered_types()
         {
             // Arrange
             var pluralizationService = new PluralizationService();
             var mm = new ModelManager(pluralizationService);
+            mm.RegisterResourceType(typeof(Post));
+            mm.RegisterResourceType(typeof(Author));
+            mm.RegisterResourceType(typeof(Comment));
+            mm.RegisterResourceType(typeof(UserGroup));
 
             // Act
-            var postKey = mm.GetJsonKeyForType(typeof(Post));
-            var authorKey = mm.GetJsonKeyForType(typeof(Author));
-            var commentKey = mm.GetJsonKeyForType(typeof(Comment));
-            var manyCommentKey = mm.GetJsonKeyForType(typeof(Comment[]));
-            var userGroupsKey = mm.GetJsonKeyForType(typeof(UserGroup));
+            var postKey = mm.GetResourceTypeNameForType(typeof(Post));
+            var authorKey = mm.GetResourceTypeNameForType(typeof(Author));
+            var commentKey = mm.GetResourceTypeNameForType(typeof(Comment));
+            var manyCommentKey = mm.GetResourceTypeNameForType(typeof(Comment[]));
+            var userGroupsKey = mm.GetResourceTypeNameForType(typeof(UserGroup));
 
             // Assert
             Assert.AreEqual("posts", postKey);
@@ -83,6 +88,64 @@ namespace JSONAPI.Tests.Core
             Assert.AreEqual("comments", commentKey);
             Assert.AreEqual("comments", manyCommentKey);
             Assert.AreEqual("user-groups", userGroupsKey);
+        }
+
+        [TestMethod]
+        public void GetResourceTypeNameForType_fails_when_getting_unregistered_type()
+        {
+            // Arrange
+            var pluralizationService = new PluralizationService();
+            var mm = new ModelManager(pluralizationService);
+
+            // Act
+            Action action = () =>
+            {
+                mm.GetResourceTypeNameForType(typeof(Post));
+            };
+
+            // Assert
+            action.ShouldThrow<InvalidOperationException>().WithMessage("The type `JSONAPI.Tests.Models.Post` was not registered.");
+        }
+
+        [TestMethod]
+        public void GetTypeByResourceTypeName_returns_correct_value_for_registered_names()
+        {
+            // Arrange
+            var pluralizationService = new PluralizationService();
+            var mm = new ModelManager(pluralizationService);
+            mm.RegisterResourceType(typeof(Post));
+            mm.RegisterResourceType(typeof(Author));
+            mm.RegisterResourceType(typeof(Comment));
+            mm.RegisterResourceType(typeof(UserGroup));
+
+            // Act
+            var postType = mm.GetTypeByResourceTypeName("posts");
+            var authorType = mm.GetTypeByResourceTypeName("authors");
+            var commentType = mm.GetTypeByResourceTypeName("comments");
+            var userGroupType = mm.GetTypeByResourceTypeName("user-groups");
+
+            // Assert
+            postType.Should().Be(typeof (Post));
+            authorType.Should().Be(typeof (Author));
+            commentType.Should().Be(typeof (Comment));
+            userGroupType.Should().Be(typeof (UserGroup));
+        }
+
+        [TestMethod]
+        public void GetTypeByResourceTypeName_fails_when_getting_unregistered_name()
+        {
+            // Arrange
+            var pluralizationService = new PluralizationService();
+            var mm = new ModelManager(pluralizationService);
+
+            // Act
+            Action action = () =>
+            {
+                mm.GetTypeByResourceTypeName("posts");
+            };
+
+            // Assert
+            action.ShouldThrow<InvalidOperationException>().WithMessage("The resource type name `posts` was not registered.");
         }
 
         [TestMethod]

--- a/JSONAPI.Tests/Json/JsonApiMediaFormatterTests.cs
+++ b/JSONAPI.Tests/Json/JsonApiMediaFormatterTests.cs
@@ -205,16 +205,14 @@ namespace JSONAPI.Tests.Json
         public void SerializerIntegrationTest()
         {
             // Arrange
-            //PayloadConverter pc = new PayloadConverter();
-            //ModelConverter mc = new ModelConverter();
-            //ContractResolver.PluralizationService = new PluralizationService();
-
-            JsonApiFormatter formatter = new JSONAPI.Json.JsonApiFormatter(new JSONAPI.Core.PluralizationService());
+            var modelManager = new ModelManager(new PluralizationService());
+            modelManager.RegisterResourceType(typeof(Author));
+            modelManager.RegisterResourceType(typeof(Comment));
+            modelManager.RegisterResourceType(typeof(Post));
+            var formatter = new JsonApiFormatter(modelManager);
             MemoryStream stream = new MemoryStream();
 
             // Act
-            //Payload payload = new Payload(a.Posts);
-            //js.Serialize(jw, payload);
             formatter.WriteToStreamAsync(typeof(Post), new[] { p, p2, p3, p4 }.ToList(), stream, (System.Net.Http.HttpContent)null, (System.Net.TransportContext)null);
 
             // Assert
@@ -230,16 +228,14 @@ namespace JSONAPI.Tests.Json
         public void SerializeArrayIntegrationTest()
         {
             // Arrange
-            //PayloadConverter pc = new PayloadConverter();
-            //ModelConverter mc = new ModelConverter();
-            //ContractResolver.PluralizationService = new PluralizationService();
-
-            JsonApiFormatter formatter = new JSONAPI.Json.JsonApiFormatter(new JSONAPI.Core.PluralizationService());
+            var modelManager = new ModelManager(new PluralizationService());
+            modelManager.RegisterResourceType(typeof(Author));
+            modelManager.RegisterResourceType(typeof(Comment));
+            modelManager.RegisterResourceType(typeof(Post));
+            var formatter = new JsonApiFormatter(modelManager);
             MemoryStream stream = new MemoryStream();
 
             // Act
-            //Payload payload = new Payload(a.Posts);
-            //js.Serialize(jw, payload);
             formatter.WriteToStreamAsync(typeof(Post), new[] { p, p2, p3, p4 }, stream, (System.Net.Http.HttpContent)null, (System.Net.TransportContext)null);
 
             // Assert
@@ -255,7 +251,9 @@ namespace JSONAPI.Tests.Json
         public void Serializes_attributes_properly() 
         {
             // Arrang
-            JsonApiFormatter formatter = new JsonApiFormatter(new PluralizationService());
+            var modelManager = new ModelManager(new PluralizationService());
+            modelManager.RegisterResourceType(typeof(Sample));
+            var formatter = new JsonApiFormatter(modelManager);
             MemoryStream stream = new MemoryStream();
 
             // Act
@@ -273,7 +271,9 @@ namespace JSONAPI.Tests.Json
         public void Serializes_byte_ids_properly() 
         {
             // Arrang
-            JsonApiFormatter formatter = new JsonApiFormatter(new PluralizationService());
+            var modelManager = new ModelManager(new PluralizationService());
+            modelManager.RegisterResourceType(typeof(Tag));
+            var formatter = new JsonApiFormatter(modelManager);
             MemoryStream stream = new MemoryStream();
 
             // Act
@@ -291,7 +291,9 @@ namespace JSONAPI.Tests.Json
         public void Reformats_raw_json_string_with_unquoted_keys()
         {
             // Arrange
-            JsonApiFormatter formatter = new JsonApiFormatter(new PluralizationService());
+            var modelManager = new ModelManager(new PluralizationService());
+            modelManager.RegisterResourceType(typeof(Comment));
+            var formatter = new JsonApiFormatter(modelManager);
             MemoryStream stream = new MemoryStream();
 
             // Act
@@ -310,7 +312,9 @@ namespace JSONAPI.Tests.Json
         public void Does_not_serialize_malformed_raw_json_string()
         {
             // Arrange
-            JsonApiFormatter formatter = new JsonApiFormatter(new PluralizationService());
+            var modelManager = new ModelManager(new PluralizationService());
+            modelManager.RegisterResourceType(typeof(Comment));
+            var formatter = new JsonApiFormatter(modelManager);
             MemoryStream stream = new MemoryStream();
 
             // Act
@@ -329,7 +333,8 @@ namespace JSONAPI.Tests.Json
         public void Should_serialize_error()
         {
             // Arrange
-            var formatter = new JSONAPI.Json.JsonApiFormatter(new MockErrorSerializer());
+            var modelManager = new ModelManager(new PluralizationService());
+            var formatter = new JsonApiFormatter(modelManager, new MockErrorSerializer());
             var stream = new MemoryStream();
 
             // Act
@@ -348,7 +353,8 @@ namespace JSONAPI.Tests.Json
         public void SerializeErrorIntegrationTest()
         {
             // Arrange
-            JsonApiFormatter formatter = new JSONAPI.Json.JsonApiFormatter(new JSONAPI.Core.PluralizationService());
+            var modelManager = new ModelManager(new PluralizationService());
+            var formatter = new JsonApiFormatter(modelManager);
             MemoryStream stream = new MemoryStream();
 
             var mockInnerException = new Mock<Exception>(MockBehavior.Strict);
@@ -384,7 +390,9 @@ namespace JSONAPI.Tests.Json
             using (var inputStream = File.OpenRead("DeserializeCollectionRequest.json"))
             {
                 // Arrange
-                JsonApiFormatter formatter = new JsonApiFormatter(new PluralizationService());
+                var modelManager = new ModelManager(new PluralizationService());
+                modelManager.RegisterResourceType(typeof(Post));
+                var formatter = new JsonApiFormatter(modelManager);
 
                 // Act
                 var posts = (IList<Post>)formatter.ReadFromStreamAsync(typeof(Post), inputStream, null, null).Result;
@@ -407,7 +415,9 @@ namespace JSONAPI.Tests.Json
             using (var inputStream = File.OpenRead("DeserializeAttributeRequest.json"))
             {
                 // Arrange
-                JsonApiFormatter formatter = new JsonApiFormatter(new PluralizationService());
+                var modelManager = new ModelManager(new PluralizationService());
+                modelManager.RegisterResourceType(typeof(Sample));
+                var formatter = new JsonApiFormatter(modelManager);
 
                 // Act
                 var deserialized = (IList<Sample>)await formatter.ReadFromStreamAsync(typeof(Sample), inputStream, null, null);
@@ -426,7 +436,9 @@ namespace JSONAPI.Tests.Json
             using (var inputStream = File.OpenRead("DeserializeRawJsonTest.json"))
             {
                 // Arrange
-                var formatter = new JsonApiFormatter(new PluralizationService());
+                var modelManager = new ModelManager(new PluralizationService());
+                modelManager.RegisterResourceType(typeof(Comment));
+                var formatter = new JsonApiFormatter(modelManager);
 
                 // Act
                 var comments = ((IEnumerable<Comment>)await formatter.ReadFromStreamAsync(typeof (Comment), inputStream, null, null)).ToArray();
@@ -442,7 +454,10 @@ namespace JSONAPI.Tests.Json
         [TestMethod(), Timeout(1000)]
         public void DeserializeExtraPropertyTest()
         {
-            JsonApiFormatter formatter = new JSONAPI.Json.JsonApiFormatter(new JSONAPI.Core.PluralizationService());
+            // Arrange
+            var modelManager = new ModelManager(new PluralizationService());
+            modelManager.RegisterResourceType(typeof(Author));
+            var formatter = new JsonApiFormatter(modelManager);
             MemoryStream stream = new MemoryStream();
 
             stream = new MemoryStream(System.Text.Encoding.ASCII.GetBytes(@"{""authors"":{""id"":13,""name"":""Jason Hater"",""bogus"":""PANIC!"",""links"":{""posts"":{""type"": ""posts"",""ids"": []}}}"));
@@ -459,7 +474,10 @@ namespace JSONAPI.Tests.Json
         [TestMethod(), Timeout(1000)]
         public void DeserializeExtraRelationshipTest()
         {
-            JsonApiFormatter formatter = new JSONAPI.Json.JsonApiFormatter(new JSONAPI.Core.PluralizationService());
+            // Arrange
+            var modelManager = new ModelManager(new PluralizationService());
+            modelManager.RegisterResourceType(typeof(Author));
+            var formatter = new JsonApiFormatter(modelManager);
             MemoryStream stream = new MemoryStream();
 
             stream = new MemoryStream(System.Text.Encoding.ASCII.GetBytes(@"{""authors"":{""id"":13,""name"":""Jason Hater"",""links"":{""posts"":{""type"": ""posts"",""ids"": []},""bogus"":[""PANIC!""]}}}"));
@@ -476,7 +494,10 @@ namespace JSONAPI.Tests.Json
         [DeploymentItem(@"Data\NonStandardIdTest.json")]
         public void SerializeNonStandardIdTest()
         {
-            var formatter = new JSONAPI.Json.JsonApiFormatter(new PluralizationService());
+            // Arrange
+            var modelManager = new ModelManager(new PluralizationService());
+            modelManager.RegisterResourceType(typeof(NonStandardIdThing));
+            var formatter = new JsonApiFormatter(modelManager);
             var stream = new MemoryStream();
             var payload = new List<NonStandardIdThing> {
                 new NonStandardIdThing { Uuid = new Guid("0657fd6d-a4ab-43c4-84e5-0933c84b4f4f"), Data = "Swap" }
@@ -498,7 +519,9 @@ namespace JSONAPI.Tests.Json
         [DeploymentItem(@"Data\NonStandardIdTest.json")]
         public void DeserializeNonStandardIdTest()
         {
-            var formatter = new JSONAPI.Json.JsonApiFormatter(new PluralizationService());
+            var modelManager = new ModelManager(new PluralizationService());
+            modelManager.RegisterResourceType(typeof(NonStandardIdThing));
+            var formatter = new JsonApiFormatter(modelManager);
             var stream = new FileStream("NonStandardIdTest.json",FileMode.Open);
 
             // Act
@@ -515,7 +538,9 @@ namespace JSONAPI.Tests.Json
         [DeploymentItem(@"Data\NonStandardIdTest.json")]
         public void DeserializeNonStandardIdWithIdOnly()
         {
-            var formatter = new JSONAPI.Json.JsonApiFormatter(new PluralizationService());
+            var modelManager = new ModelManager(new PluralizationService());
+            modelManager.RegisterResourceType(typeof(NonStandardIdThing));
+            var formatter = new JsonApiFormatter(modelManager);
             string json = File.ReadAllText("NonStandardIdTest.json");
             json = Regex.Replace(json, @"""uuid"":\s*""0657fd6d-a4ab-43c4-84e5-0933c84b4f4f""\s*,",""); // remove the uuid attribute
             var stream = new MemoryStream(System.Text.Encoding.ASCII.GetBytes(json));
@@ -534,7 +559,9 @@ namespace JSONAPI.Tests.Json
         [DeploymentItem(@"Data\NonStandardIdTest.json")]
         public void DeserializeNonStandardIdWithoutId()
         {
-            var formatter = new JSONAPI.Json.JsonApiFormatter(new PluralizationService());
+            var modelManager = new ModelManager(new PluralizationService());
+            modelManager.RegisterResourceType(typeof(NonStandardIdThing));
+            var formatter = new JsonApiFormatter(modelManager);
             string json = File.ReadAllText("NonStandardIdTest.json");
             json = Regex.Replace(json, @"""id"":\s*""0657fd6d-a4ab-43c4-84e5-0933c84b4f4f""\s*,", ""); // remove the uuid attribute
             var stream = new MemoryStream(System.Text.Encoding.ASCII.GetBytes(json));

--- a/JSONAPI.Tests/Json/LinkTemplateTests.cs
+++ b/JSONAPI.Tests/Json/LinkTemplateTests.cs
@@ -4,6 +4,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
+using JSONAPI.Core;
 
 namespace JSONAPI.Tests.Json
 {
@@ -49,10 +50,9 @@ namespace JSONAPI.Tests.Json
         [DeploymentItem(@"Data\LinkTemplateTest.json")]
         public void GetResourceWithLinkTemplateRelationship()
         {
-            var formatter = new JsonApiFormatter
-            (
-                new JSONAPI.Core.PluralizationService()
-            );
+            var modelManager = new ModelManager(new PluralizationService());
+            modelManager.RegisterResourceType(typeof(Post));
+            var formatter = new JsonApiFormatter(modelManager);
             var stream = new MemoryStream();
 
             formatter.WriteToStreamAsync(typeof(Post), ThePost, stream, null, null);

--- a/JSONAPI.TodoMVC.API/Startup.cs
+++ b/JSONAPI.TodoMVC.API/Startup.cs
@@ -5,6 +5,7 @@ using JSONAPI.Core;
 using JSONAPI.EntityFramework.ActionFilters;
 using JSONAPI.Http;
 using JSONAPI.Json;
+using JSONAPI.TodoMVC.API.Models;
 using Owin;
 
 namespace JSONAPI.TodoMVC.API
@@ -24,6 +25,7 @@ namespace JSONAPI.TodoMVC.API
             var config = new HttpConfiguration();
 
             var modelManager = new ModelManager(pluralizationService);
+            modelManager.RegisterResourceType(typeof(Todo));
 
             var formatter = new JsonApiFormatter(modelManager);
             config.Formatters.Clear();

--- a/JSONAPI/ActionFilters/EnableSortingAttribute.cs
+++ b/JSONAPI/ActionFilters/EnableSortingAttribute.cs
@@ -90,7 +90,7 @@ namespace JSONAPI.ActionFilters
 
                 if (property == null)
                     throw new SortingException(string.Format("The attribute \"{0}\" does not exist on type \"{1}\".",
-                        propertyName, _modelManager.GetJsonKeyForType(typeof (T))));
+                        propertyName, _modelManager.GetResourceTypeNameForType(typeof (T))));
                 
                 if (usedProperties.ContainsKey(property))
                     throw new SortingException(string.Format("The attribute \"{0}\" was specified more than once.", propertyName));

--- a/JSONAPI/Core/IModelManager.cs
+++ b/JSONAPI/Core/IModelManager.cs
@@ -25,13 +25,20 @@ namespace JSONAPI.Core
         PropertyInfo GetIdProperty(Type type);
 
         /// <summary>
-        /// Returns the key that will be used to represent a collection of objects of a
-        /// given type, for example in the top-level of a JSON API document or within
-        /// the "linked" objects section of a payload.
+        /// Returns the name that will be used to represent this type in json-api documents. 
+        /// The `type` property of resource objects of this type will have this value.
         /// </summary>
         /// <param name="type">The serializable Type</param>
         /// <returns>The string denoting the given type in JSON documents.</returns>
-        string GetJsonKeyForType(Type type);
+        string GetResourceTypeNameForType(Type type);
+
+        /// <summary>
+        /// Gets the registered Type corresponding to a json-api resource type name. Inverse
+        /// of <see cref="GetResourceTypeNameForType" />
+        /// </summary>
+        /// <param name="resourceTypeName"></param>
+        /// <returns>The type that has been registered for this resource type name.</returns>
+        Type GetTypeByResourceTypeName(string resourceTypeName);
 
         /// <summary>
         /// Returns the key that will be used to represent the given property in serialized

--- a/JSONAPI/Core/ModelManager.cs
+++ b/JSONAPI/Core/ModelManager.cs
@@ -136,8 +136,15 @@ namespace JSONAPI.Core
             if (IsSerializedAsMany(type))
                 type = GetElementType(type);
 
-            string resourceTypeName;
-            if (_resourceTypeNamesByType.Value.TryGetValue(type, out resourceTypeName)) return resourceTypeName;
+            var currentType = type;
+            while (currentType != null && currentType != typeof(Object))
+            {
+                string resourceTypeName;
+                if (_resourceTypeNamesByType.Value.TryGetValue(currentType, out resourceTypeName)) return resourceTypeName;
+
+                // This particular type wasn't registered, but maybe the base type was
+                currentType = currentType.BaseType;
+            }
 
             throw new InvalidOperationException(String.Format("The type `{0}` was not registered.", type.FullName));
         }

--- a/JSONAPI/Core/ModelManager.cs
+++ b/JSONAPI/Core/ModelManager.cs
@@ -38,9 +38,14 @@ namespace JSONAPI.Core
                 () => new Dictionary<Type, Dictionary<string, PropertyInfo>>()
             );
 
-        protected Lazy<Dictionary<Type, string>> _jsonKeysForType
+        protected Lazy<Dictionary<Type, string>> _resourceTypeNamesByType
             = new Lazy<Dictionary<Type, string>>(
                 () => new Dictionary<Type, string>()
+            );
+
+        protected Lazy<Dictionary<string, Type>> _typesByResourceTypeName
+            = new Lazy<Dictionary<string, Type>>(
+                () => new Dictionary<string, Type>()
             );
 
         protected Lazy<Dictionary<Type, bool>> _isSerializedAsMany
@@ -126,35 +131,78 @@ namespace JSONAPI.Core
 
         #endregion
 
-        public string GetJsonKeyForType(Type type)
+        public string GetResourceTypeNameForType(Type type)
         {
-            string key = null;
+            if (IsSerializedAsMany(type))
+                type = GetElementType(type);
 
-            var keyCache = _jsonKeysForType.Value;
+            string resourceTypeName;
+            if (_resourceTypeNamesByType.Value.TryGetValue(type, out resourceTypeName)) return resourceTypeName;
 
-            lock (keyCache)
+            throw new InvalidOperationException(String.Format("The type `{0}` was not registered.", type.FullName));
+        }
+
+        public Type GetTypeByResourceTypeName(string resourceTypeName)
+        {
+            Type type;
+            if (_typesByResourceTypeName.Value.TryGetValue(resourceTypeName, out type)) return type;
+
+            throw new InvalidOperationException(String.Format("The resource type name `{0}` was not registered.", resourceTypeName));
+        }
+
+        /// <summary>
+        /// Registers a type with this ModelManager.
+        /// </summary>
+        /// <param name="type">The type to register.</param>
+        public void RegisterResourceType(Type type)
+        {
+            var resourceTypeName = CalculateResourceTypeNameForType(type);
+            RegisterResourceType(type, resourceTypeName);
+        }
+
+        /// <summary>
+        /// Registeres a type with this ModelManager, using a default resource type name.
+        /// </summary>
+        /// <param name="type">The type to register.</param>
+        /// <param name="resourceTypeName">The resource type name to use</param>
+        public void RegisterResourceType(Type type, string resourceTypeName)
+        {
+            lock (_resourceTypeNamesByType.Value)
             {
-                if (IsSerializedAsMany(type))
-                    type = GetElementType(type);
-
-                if (keyCache.TryGetValue(type, out key)) return key;
-
-                var attrs = type.CustomAttributes.Where(x => x.AttributeType == typeof(Newtonsoft.Json.JsonObjectAttribute)).ToList();
-
-                string title = type.Name;
-                if (attrs.Any())
+                lock (_typesByResourceTypeName.Value)
                 {
-                    var titles = attrs.First().NamedArguments.Where(arg => arg.MemberName == "Title")
-                        .Select(arg => arg.TypedValue.Value.ToString()).ToList();
-                    if (titles.Any()) title = titles.First();
+                    if (_resourceTypeNamesByType.Value.ContainsKey(type))
+                        throw new InvalidOperationException(String.Format("The type `{0}` has already been registered.",
+                            type.FullName));
+
+                    if (_typesByResourceTypeName.Value.ContainsKey(resourceTypeName))
+                        throw new InvalidOperationException(
+                            String.Format("The resource type name `{0}` has already been registered.", resourceTypeName));
+
+                    _resourceTypeNamesByType.Value[type] = resourceTypeName;
+                    _typesByResourceTypeName.Value[resourceTypeName] = type;
                 }
+            }
+        }
 
-                key = FormatPropertyName(PluralizationService.Pluralize(title)).Dasherize();
+        /// <summary>
+        /// Determines the resource type name for a given type.
+        /// </summary>
+        /// <param name="type">The type to calculate the resouce type name for</param>
+        /// <returns>The type's resource type name</returns>
+        protected virtual string CalculateResourceTypeNameForType(Type type)
+        {
+            var attrs = type.CustomAttributes.Where(x => x.AttributeType == typeof(Newtonsoft.Json.JsonObjectAttribute)).ToList();
 
-                keyCache.Add(type, key);
+            string title = type.Name;
+            if (attrs.Any())
+            {
+                var titles = attrs.First().NamedArguments.Where(arg => arg.MemberName == "Title")
+                    .Select(arg => arg.TypedValue.Value.ToString()).ToList();
+                if (titles.Any()) title = titles.First();
             }
 
-            return key;
+            return FormatPropertyName(PluralizationService.Pluralize(title)).Dasherize();
         }
 
         public string GetJsonKeyForProperty(PropertyInfo propInfo)

--- a/JSONAPI/Json/JsonApiFormatter.cs
+++ b/JSONAPI/Json/JsonApiFormatter.cs
@@ -123,7 +123,7 @@ namespace JSONAPI.Json
 
                 //writer.Formatting = Formatting.Indented;
 
-                var root = _modelManager.GetJsonKeyForType(type);
+                var root = _modelManager.GetResourceTypeNameForType(type);
 
                 writer.WriteStartObject();
                 writer.WritePropertyName(root);
@@ -469,7 +469,7 @@ namespace JSONAPI.Json
                 foreach (KeyValuePair<Type, KeyValuePair<JsonWriter, StringWriter>> apair in writers)
                 {
                     apair.Value.Key.WriteEnd(); // close off the array
-                    writer.WritePropertyName(_modelManager.GetJsonKeyForType(apair.Key));
+                    writer.WritePropertyName(_modelManager.GetResourceTypeNameForType(apair.Key));
                     writer.WriteRawValue(apair.Value.Value.ToString()); // write the contents of the type JsonWriter's StringWriter to the main JsonWriter
                 }
 
@@ -501,7 +501,7 @@ namespace JSONAPI.Json
         {
             object retval = null;
             Type singleType = GetSingleType(type);
-            var pripropname = _modelManager.GetJsonKeyForType(type);
+            var pripropname = _modelManager.GetResourceTypeNameForType(type);
             var contentHeaders = content == null ? null : content.Headers;
 
             // If content length is 0 then return default value for this type


### PR DESCRIPTION
This PR paves the way for polymorphism (#73) and heterogeneous collection support by requiring the user to pre-register all resource types. This will be a major breaking change as existing apps will fail until they add their necessary registrations.

I changed the language of `GetJsonKeyForType` to `GetResouceTypeNameForType` because the spec no longer wants primary data to be keyed by type, but rather by the word `data`. "Resource type name" seemed a more apt description of what we are determining.

I also added a virtual method on `ModelManager` called `CalculateResourceTypeNameForType` which will allow sub-classes to override the default strategy for determining the resource type name.

@SphtKr do you have any concerns?