### PR TITLE
Add type property and key primary data at `data`

### DIFF
--- a/JSONAPI.EntityFramework.Tests.TestWebApp/Controllers/SearchController.cs
+++ b/JSONAPI.EntityFramework.Tests.TestWebApp/Controllers/SearchController.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Generic;
+using System.Data.Entity;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Web.Http;
+using JSONAPI.EntityFramework.Tests.TestWebApp.Models;
+
+namespace JSONAPI.EntityFramework.Tests.TestWebApp.Controllers
+{
+    public class SearchController : ApiController
+    {
+        private readonly TestDbContext _dbContext;
+
+        public SearchController(TestDbContext dbContext)
+        {
+            _dbContext = dbContext;
+        }
+
+        public async Task<IEnumerable<object>> Get(string s)
+        {
+            IEnumerable<object> posts = await _dbContext.Posts.Where(p => p.Title.Contains(s)).ToArrayAsync();
+            IEnumerable<object> comments = await _dbContext.Comments.Where(p => p.Text.Contains(s)).ToArrayAsync();
+            return posts.Concat(comments);
+        }
+    }
+}

--- a/JSONAPI.EntityFramework.Tests.TestWebApp/JSONAPI.EntityFramework.Tests.TestWebApp.csproj
+++ b/JSONAPI.EntityFramework.Tests.TestWebApp/JSONAPI.EntityFramework.Tests.TestWebApp.csproj
@@ -115,6 +115,7 @@
     <Content Include="Web.config" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Controllers\SearchController.cs" />
     <Compile Include="Controllers\CommentsController.cs" />
     <Compile Include="Controllers\UserGroupsController.cs" />
     <Compile Include="Controllers\UsersController.cs" />

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Heterogeneous/Responses/GetSearchResultsResponse.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Heterogeneous/Responses/GetSearchResultsResponse.json
@@ -1,0 +1,26 @@
+﻿{
+    "data": [
+        {
+            "type": "posts",
+            "id": "201",
+            "title": "Post 1",
+            "content": "Post 1 content",
+            "created": "2015-01-31T14:00:00+00:00",
+            "links": {
+                "author": "401",
+                "comments": [ "101", "102", "103" ],
+                "tags": [ "301", "302" ]
+            }
+        },
+        {
+            "type": "comments",
+            "id": "101",
+            "text": "Comment 1",
+            "created": "2015-01-31T14:30:00+00:00",
+            "links": { 
+                "author": "403",
+                "post": "201"
+            }
+        }
+    ]
+}

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Requests/PostRequest.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Requests/PostRequest.json
@@ -1,6 +1,7 @@
 ﻿{
-    "posts": [
+    "data": [
         {
+            "type": "posts",
             "id": "205",
             "title": "Added post",
             "content": "Added post content",

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Requests/PutWithArrayRelationshipValueRequest.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Requests/PutWithArrayRelationshipValueRequest.json
@@ -1,6 +1,7 @@
 ﻿{
-    "posts": [
+    "data": [
         {
+            "type": "posts",
             "id": "202",
             "links": {
                 "tags": ["301"]

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Requests/PutWithAttributeUpdateRequest.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Requests/PutWithAttributeUpdateRequest.json
@@ -1,6 +1,7 @@
 ﻿{
-    "posts": [
+    "data": [
         {
+            "type": "posts",
             "id": "202",
             "title": "New post title"
         }

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Requests/PutWithMissingToManyIdsRequest.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Requests/PutWithMissingToManyIdsRequest.json
@@ -1,6 +1,7 @@
 ﻿{
-    "posts": [
+    "data": [
         {
+            "type": "posts",
             "id": "202",
             "links": {
                 "tags": {

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Requests/PutWithMissingToManyTypeRequest.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Requests/PutWithMissingToManyTypeRequest.json
@@ -1,6 +1,7 @@
 ﻿{
-    "posts": [
+    "data": [
         {
+            "type": "posts",
             "id": "202",
             "links": {
                 "tags": {

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Requests/PutWithMissingToOneIdRequest.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Requests/PutWithMissingToOneIdRequest.json
@@ -1,6 +1,7 @@
 ﻿{
-    "posts": [
+    "data": [
         {
+            "type": "posts",
             "id": "202",
             "links": {
                 "author": {

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Requests/PutWithMissingToOneTypeRequest.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Requests/PutWithMissingToOneTypeRequest.json
@@ -1,6 +1,7 @@
 ﻿{
-    "posts": [
+    "data": [
         {
+            "type": "posts",
             "id": "202",
             "links": {
                 "author": {

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Requests/PutWithNullToOneUpdateRequest.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Requests/PutWithNullToOneUpdateRequest.json
@@ -1,6 +1,7 @@
 ﻿{
-    "posts": [
+    "data": [
         {
+            "type": "posts",
             "id": "202",
             "links": {
                 "author": null

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Requests/PutWithStringRelationshipValueRequest.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Requests/PutWithStringRelationshipValueRequest.json
@@ -1,6 +1,7 @@
 ﻿{
-    "posts": [
+    "data": [
         {
+            "type": "posts",
             "id": "202",
             "links": {
                 "author": "301"

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Requests/PutWithToManyEmptyDataUpdateRequest.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Requests/PutWithToManyEmptyDataUpdateRequest.json
@@ -1,6 +1,7 @@
 ﻿{
-    "posts": [
+    "data": [
         {
+            "type": "posts",
             "id": "202",
             "links": {
                 "tags": {

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Requests/PutWithToManyHomogeneousDataUpdateRequest.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Requests/PutWithToManyHomogeneousDataUpdateRequest.json
@@ -1,6 +1,7 @@
 ﻿{
-    "posts": [
+    "data": [
         {
+            "type": "posts",
             "id": "202",
             "links": {
                 "tags": {

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Requests/PutWithToManyUpdateRequest.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Requests/PutWithToManyUpdateRequest.json
@@ -1,6 +1,7 @@
 ﻿{
-    "posts": [
+    "data": [
         {
+            "type": "posts",
             "id": "202",
             "links": {
                 "tags": {

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Requests/PutWithToOneUpdateRequest.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Requests/PutWithToOneUpdateRequest.json
@@ -1,6 +1,7 @@
 ﻿{
-    "posts": [
+    "data": [
         {
+            "type": "posts",
             "id": "202",
             "links": {
                 "author": {

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Responses/GetAllResponse.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Responses/GetAllResponse.json
@@ -1,6 +1,7 @@
 ﻿{
     "posts": [
         {
+            "type": "posts",
             "id": "201",
             "title": "Post 1",
             "content": "Post 1 content",
@@ -12,6 +13,7 @@
             }
         },
         {
+            "type": "posts",
             "id": "202",
             "title": "Post 2",
             "content": "Post 2 content",
@@ -23,6 +25,7 @@
             }
         },
         {
+            "type": "posts",
             "id": "203",
             "title": "Post 3",
             "content": "Post 3 content",
@@ -34,6 +37,7 @@
             }
         },
         {
+            "type": "posts",
             "id": "204",
             "title": "Post 4",
             "content": "Post 4 content",

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Responses/GetAllResponse.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Responses/GetAllResponse.json
@@ -1,5 +1,5 @@
 ﻿{
-    "posts": [
+    "data": [
         {
             "type": "posts",
             "id": "201",

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Responses/GetByIdResponse.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Responses/GetByIdResponse.json
@@ -1,6 +1,7 @@
 ﻿{
     "posts": [
         {
+            "type": "posts",
             "id": "202",
             "title": "Post 2",
             "content": "Post 2 content",

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Responses/GetByIdResponse.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Responses/GetByIdResponse.json
@@ -1,5 +1,5 @@
 ﻿{
-    "posts": [
+    "data": [
         {
             "type": "posts",
             "id": "202",

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Responses/GetWithFilterResponse.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Responses/GetWithFilterResponse.json
@@ -1,6 +1,7 @@
 ﻿{
     "posts": [
         {
+            "type": "posts",
             "id": "204",
             "title": "Post 4",
             "content": "Post 4 content",

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Responses/GetWithFilterResponse.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Responses/GetWithFilterResponse.json
@@ -1,5 +1,5 @@
 ﻿{
-    "posts": [
+    "data": [
         {
             "type": "posts",
             "id": "204",

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Responses/PostResponse.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Responses/PostResponse.json
@@ -1,6 +1,7 @@
 ﻿{
     "posts": [
         {
+            "type": "posts",
             "id": "205",
             "title": "Added post",
             "content": "Added post content",

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Responses/PostResponse.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Responses/PostResponse.json
@@ -1,5 +1,5 @@
 ﻿{
-    "posts": [
+    "data": [
         {
             "type": "posts",
             "id": "205",

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Responses/PutWithAttributeUpdateResponse.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Responses/PutWithAttributeUpdateResponse.json
@@ -1,6 +1,7 @@
 ﻿{
     "posts": [
         {
+            "type": "posts",
             "id": "202",
             "title": "New post title",
             "content": "Post 2 content",

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Responses/PutWithAttributeUpdateResponse.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Responses/PutWithAttributeUpdateResponse.json
@@ -1,5 +1,5 @@
 ﻿{
-    "posts": [
+    "data": [
         {
             "type": "posts",
             "id": "202",

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Responses/PutWithNullToOneUpdateResponse.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Responses/PutWithNullToOneUpdateResponse.json
@@ -1,6 +1,7 @@
 ﻿{
     "posts": [
         {
+            "type": "posts",
             "id": "202",
             "title": "Post 2",
             "content": "Post 2 content",

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Responses/PutWithNullToOneUpdateResponse.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Responses/PutWithNullToOneUpdateResponse.json
@@ -1,5 +1,5 @@
 ﻿{
-    "posts": [
+    "data": [
         {
             "type": "posts",
             "id": "202",

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Responses/PutWithToManyEmptyDataUpdateResponse.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Responses/PutWithToManyEmptyDataUpdateResponse.json
@@ -1,6 +1,7 @@
 ﻿{
     "posts": [
         {
+            "type": "posts",
             "id": "202",
             "title": "Post 2",
             "content": "Post 2 content",

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Responses/PutWithToManyEmptyDataUpdateResponse.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Responses/PutWithToManyEmptyDataUpdateResponse.json
@@ -1,5 +1,5 @@
 ﻿{
-    "posts": [
+    "data": [
         {
             "type": "posts",
             "id": "202",

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Responses/PutWithToManyHomogeneousDataUpdateResponse.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Responses/PutWithToManyHomogeneousDataUpdateResponse.json
@@ -1,6 +1,7 @@
 ﻿{
     "posts": [
         {
+            "type": "posts",
             "id": "202",
             "title": "Post 2",
             "content": "Post 2 content",

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Responses/PutWithToManyHomogeneousDataUpdateResponse.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Responses/PutWithToManyHomogeneousDataUpdateResponse.json
@@ -1,5 +1,5 @@
 ﻿{
-    "posts": [
+    "data": [
         {
             "type": "posts",
             "id": "202",

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Responses/PutWithToManyUpdateResponse.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Responses/PutWithToManyUpdateResponse.json
@@ -1,6 +1,7 @@
 ﻿{
     "posts": [
         {
+            "type": "posts",
             "id": "202",
             "title": "Post 2",
             "content": "Post 2 content",

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Responses/PutWithToManyUpdateResponse.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Responses/PutWithToManyUpdateResponse.json
@@ -1,5 +1,5 @@
 ﻿{
-    "posts": [
+    "data": [
         {
             "type": "posts",
             "id": "202",

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Responses/PutWithToOneUpdateResponse.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Responses/PutWithToOneUpdateResponse.json
@@ -1,6 +1,7 @@
 ﻿{
     "posts": [
         {
+            "type": "posts",
             "id": "202",
             "title": "Post 2",
             "content": "Post 2 content",

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Responses/PutWithToOneUpdateResponse.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Posts/Responses/PutWithToOneUpdateResponse.json
@@ -1,5 +1,5 @@
 ﻿{
-    "posts": [
+    "data": [
         {
             "type": "posts",
             "id": "202",

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Sorting/Responses/GetSortedAscendingResponse.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Sorting/Responses/GetSortedAscendingResponse.json
@@ -1,6 +1,7 @@
 ﻿{
     "users": [
         {
+            "type": "users",
             "id": "401",
             "firstName": "Alice",
             "lastName": "Smith",
@@ -11,6 +12,7 @@
             }
         },
         {
+            "type": "users",
             "id": "402",
             "firstName": "Bob",
             "lastName": "Jones",
@@ -21,6 +23,7 @@
             }
         },
         {
+            "type": "users",
             "id": "403",
             "firstName": "Charlie",
             "lastName": "Michaels",
@@ -31,6 +34,7 @@
             }
         },
         {
+            "type": "users",
             "id": "409",
             "firstName": "Charlie",
             "lastName": "Burns",
@@ -41,6 +45,7 @@
             }
         },
         {
+            "type": "users",
             "id": "406",
             "firstName": "Ed",
             "lastName": "Burns",
@@ -51,6 +56,7 @@
             }
         },
         {
+            "type": "users",
             "id": "405",
             "firstName": "Michelle",
             "lastName": "Johnson",
@@ -61,6 +67,7 @@
             }
         },
         {
+            "type": "users",
             "id": "408",
             "firstName": "Pat",
             "lastName": "Morgan",
@@ -71,6 +78,7 @@
             }
         },
         {
+            "type": "users",
             "id": "404",
             "firstName": "Richard",
             "lastName": "Smith",
@@ -81,6 +89,7 @@
             }
         },
         {
+            "type": "users",
             "id": "410",
             "firstName": "Sally",
             "lastName": "Burns",
@@ -91,6 +100,7 @@
             }
         },
         {
+            "type": "users",
             "id": "407",
             "firstName": "Thomas",
             "lastName": "Potter",

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Sorting/Responses/GetSortedAscendingResponse.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Sorting/Responses/GetSortedAscendingResponse.json
@@ -1,5 +1,5 @@
 ﻿{
-    "users": [
+    "data": [
         {
             "type": "users",
             "id": "401",

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Sorting/Responses/GetSortedByMixedDirectionResponse.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Sorting/Responses/GetSortedByMixedDirectionResponse.json
@@ -1,6 +1,7 @@
 ﻿{
     "users": [
         {
+            "type": "users",
             "id": "410",
             "firstName": "Sally",
             "lastName":  "Burns",
@@ -11,6 +12,7 @@
             }
         },
         {
+            "type": "users",
             "id": "406",
             "firstName": "Ed",
             "lastName":  "Burns",
@@ -21,6 +23,7 @@
             }
         },
         {
+            "type": "users",
             "id": "409",
             "firstName": "Charlie",
             "lastName": "Burns",
@@ -31,6 +34,7 @@
             }
         },
         {
+            "type": "users",
             "id": "405",
             "firstName": "Michelle",
             "lastName":  "Johnson",
@@ -41,6 +45,7 @@
             }
         },
         {
+            "type": "users",
             "id": "402",
             "firstName": "Bob",
             "lastName":  "Jones",
@@ -51,6 +56,7 @@
             }
         },
         {
+            "type": "users",
             "id": "403",
             "firstName": "Charlie",
             "lastName":  "Michaels",
@@ -61,6 +67,7 @@
             }
         },
         {
+            "type": "users",
             "id": "408",
             "firstName": "Pat",
             "lastName":  "Morgan",
@@ -71,6 +78,7 @@
             }
         },
         {
+            "type": "users",
             "id": "407",
             "firstName": "Thomas",
             "lastName":  "Potter",
@@ -81,6 +89,7 @@
             }
         },
         {
+            "type": "users",
             "id": "404",
             "firstName": "Richard",
             "lastName":  "Smith",
@@ -91,6 +100,7 @@
             }
         },
         {
+            "type": "users",
             "id": "401",
             "firstName": "Alice",
             "lastName":  "Smith",

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Sorting/Responses/GetSortedByMixedDirectionResponse.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Sorting/Responses/GetSortedByMixedDirectionResponse.json
@@ -1,5 +1,5 @@
 ﻿{
-    "users": [
+    "data": [
         {
             "type": "users",
             "id": "410",

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Sorting/Responses/GetSortedByMultipleAscendingResponse.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Sorting/Responses/GetSortedByMultipleAscendingResponse.json
@@ -1,6 +1,7 @@
 ﻿{
     "users": [
         {
+            "type": "users",
             "id": "409",
             "firstName": "Charlie",
             "lastName": "Burns",
@@ -11,6 +12,7 @@
             }
         },
         {
+            "type": "users",
             "id": "406",
             "firstName": "Ed",
             "lastName":  "Burns",
@@ -21,6 +23,7 @@
             }
         },
         {
+            "type": "users",
             "id": "410",
             "firstName": "Sally",
             "lastName":  "Burns",
@@ -31,6 +34,7 @@
             }
         },
         {
+            "type": "users",
             "id": "405",
             "firstName": "Michelle",
             "lastName":  "Johnson",
@@ -41,6 +45,7 @@
             }
         },
         {
+            "type": "users",
             "id": "402",
             "firstName": "Bob",
             "lastName":  "Jones",
@@ -51,6 +56,7 @@
             }
         },
         {
+            "type": "users",
             "id": "403",
             "firstName": "Charlie",
             "lastName":  "Michaels",
@@ -61,6 +67,7 @@
             }
         },
         {
+            "type": "users",
             "id": "408",
             "firstName": "Pat",
             "lastName":  "Morgan",
@@ -71,6 +78,7 @@
             }
         },
         {
+            "type": "users",
             "id": "407",
             "firstName": "Thomas",
             "lastName":  "Potter",
@@ -81,6 +89,7 @@
             }
         },
         {
+            "type": "users",
             "id": "401",
             "firstName": "Alice",
             "lastName":  "Smith",
@@ -91,6 +100,7 @@
             }
         },
         {
+            "type": "users",
             "id": "404",
             "firstName": "Richard",
             "lastName":  "Smith",

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Sorting/Responses/GetSortedByMultipleAscendingResponse.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Sorting/Responses/GetSortedByMultipleAscendingResponse.json
@@ -1,5 +1,5 @@
 ﻿{
-    "users": [
+    "data": [
         {
             "type": "users",
             "id": "409",

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Sorting/Responses/GetSortedByMultipleDescendingResponse.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Sorting/Responses/GetSortedByMultipleDescendingResponse.json
@@ -1,6 +1,7 @@
 ﻿{
     "users": [
         {
+            "type": "users",
             "id": "404",
             "firstName": "Richard",
             "lastName":  "Smith",
@@ -11,6 +12,7 @@
             }
         },
         {
+            "type": "users",
             "id": "401",
             "firstName": "Alice",
             "lastName": "Smith",
@@ -21,6 +23,7 @@
             }
         },
         {
+            "type": "users",
             "id": "407",
             "firstName": "Thomas",
             "lastName": "Potter",
@@ -31,6 +34,7 @@
             }
         },
         {
+            "type": "users",
             "id": "408",
             "firstName": "Pat",
             "lastName": "Morgan",
@@ -41,6 +45,7 @@
             }
         },
         {
+            "type": "users",
             "id": "403",
             "firstName": "Charlie",
             "lastName": "Michaels",
@@ -51,6 +56,7 @@
             }
         },
         {
+            "type": "users",
             "id": "402",
             "firstName": "Bob",
             "lastName": "Jones",
@@ -61,6 +67,7 @@
             }
         },
         {
+            "type": "users",
             "id": "405",
             "firstName": "Michelle",
             "lastName": "Johnson",
@@ -71,6 +78,7 @@
             }
         },
         {
+            "type": "users",
             "id": "410",
             "firstName": "Sally",
             "lastName": "Burns",
@@ -81,6 +89,7 @@
             }
         },
         {
+            "type": "users",
             "id": "406",
             "firstName": "Ed",
             "lastName": "Burns",
@@ -91,6 +100,7 @@
             }
         },
         {
+            "type": "users",
             "id": "409",
             "firstName": "Charlie",
             "lastName": "Burns",

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Sorting/Responses/GetSortedByMultipleDescendingResponse.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Sorting/Responses/GetSortedByMultipleDescendingResponse.json
@@ -1,5 +1,5 @@
 ﻿{
-    "users": [
+    "data": [
         {
             "type": "users",
             "id": "404",

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Sorting/Responses/GetSortedDescendingResponse.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Sorting/Responses/GetSortedDescendingResponse.json
@@ -1,6 +1,7 @@
 ﻿{
     "users": [
         {
+            "type": "users",
             "id": "407",
             "firstName": "Thomas",
             "lastName":  "Potter",
@@ -11,6 +12,7 @@
             }
         },
         {
+            "type": "users",
             "id": "410",
             "firstName": "Sally",
             "lastName":  "Burns",
@@ -21,6 +23,7 @@
             }
         },
         {
+            "type": "users",
             "id": "404",
             "firstName": "Richard",
             "lastName":  "Smith",
@@ -31,6 +34,7 @@
             }
         },
         {
+            "type": "users",
             "id": "408",
             "firstName": "Pat",
             "lastName":  "Morgan",
@@ -41,6 +45,7 @@
             }
         },
         {
+            "type": "users",
             "id": "405",
             "firstName": "Michelle",
             "lastName":  "Johnson",
@@ -51,6 +56,7 @@
             }
         },
         {
+            "type": "users",
             "id": "406",
             "firstName": "Ed",
             "lastName":  "Burns",
@@ -61,6 +67,7 @@
             }
         },
         {
+            "type": "users",
             "id": "403",
             "firstName": "Charlie",
             "lastName": "Michaels",
@@ -71,6 +78,7 @@
             }
         },
         {
+            "type": "users",
             "id": "409",
             "firstName": "Charlie",
             "lastName":  "Burns",
@@ -81,6 +89,7 @@
             }
         },
         {
+            "type": "users",
             "id": "402",
             "firstName": "Bob",
             "lastName":  "Jones",
@@ -91,6 +100,7 @@
             }
         },
         {
+            "type": "users",
             "id": "401",
             "firstName": "Alice",
             "lastName":  "Smith",

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Sorting/Responses/GetSortedDescendingResponse.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Sorting/Responses/GetSortedDescendingResponse.json
@@ -1,5 +1,5 @@
 ﻿{
-    "users": [
+    "data": [
         {
             "type": "users",
             "id": "407",

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/UserGroups/Responses/GetAllResponse.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/UserGroups/Responses/GetAllResponse.json
@@ -1,5 +1,5 @@
 ﻿{
-    "user-groups": [
+    "data": [
         {
             "type": "user-groups",
             "id": "501",

--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/UserGroups/Responses/GetAllResponse.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/UserGroups/Responses/GetAllResponse.json
@@ -1,6 +1,7 @@
 ﻿{
     "user-groups": [
         {
+            "type": "user-groups",
             "id": "501",
             "name": "Admin users",
             "links": {

--- a/JSONAPI.EntityFramework.Tests/Acceptance/HeterogeneousTests.cs
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/HeterogeneousTests.cs
@@ -1,0 +1,27 @@
+﻿using System.Net;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace JSONAPI.EntityFramework.Tests.Acceptance
+{
+    [TestClass]
+    public class HeterogeneousTests : AcceptanceTestsBase
+    {
+        [TestMethod]
+        [DeploymentItem(@"Acceptance\Data\Comment.csv", @"Acceptance\Data")]
+        [DeploymentItem(@"Acceptance\Data\Post.csv", @"Acceptance\Data")]
+        [DeploymentItem(@"Acceptance\Data\PostTagLink.csv", @"Acceptance\Data")]
+        [DeploymentItem(@"Acceptance\Data\Tag.csv", @"Acceptance\Data")]
+        [DeploymentItem(@"Acceptance\Data\User.csv", @"Acceptance\Data")]
+        public async Task Get()
+        {
+            using (var effortConnection = GetEffortConnection())
+            {
+                var response = await SubmitGet(effortConnection, "search?s=1");
+
+                await AssertResponseContent(response, @"Acceptance\Fixtures\Heterogeneous\Responses\GetSearchResultsResponse.json", HttpStatusCode.OK);
+            }
+        }
+    }
+}

--- a/JSONAPI.EntityFramework.Tests/EntityConverterTests.cs
+++ b/JSONAPI.EntityFramework.Tests/EntityConverterTests.cs
@@ -108,6 +108,7 @@ namespace JSONAPI.EntityFramework.Tests
         {
             // Arrange
             var modelManager = new ModelManager(new Core.PluralizationService());
+            modelManager.RegisterResourceType(typeof(Comment));
             modelManager.RegisterResourceType(typeof(Post));
 
             JsonApiFormatter formatter = new JSONAPI.Json.JsonApiFormatter(modelManager);

--- a/JSONAPI.EntityFramework.Tests/EntityConverterTests.cs
+++ b/JSONAPI.EntityFramework.Tests/EntityConverterTests.cs
@@ -135,7 +135,7 @@ namespace JSONAPI.EntityFramework.Tests
 
             EntityFrameworkMaterializer materializer = new EntityFrameworkMaterializer(context, MetadataManager.Instance);
 
-            string underpost = @"{""posts"":{""id"":""" + p.Id.ToString() + @""",""title"":""Not at all linkbait!""}}";
+            string underpost = @"{""data"":{""id"":""" + p.Id.ToString() + @""",""title"":""Not at all linkbait!""}}";
             stream = new MemoryStream(System.Text.Encoding.ASCII.GetBytes(underpost));
 
             int previousCommentsCount = p.Comments.Count;

--- a/JSONAPI.EntityFramework.Tests/JSONAPI.EntityFramework.Tests.csproj
+++ b/JSONAPI.EntityFramework.Tests/JSONAPI.EntityFramework.Tests.csproj
@@ -110,6 +110,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Acceptance\HeterogeneousTests.cs" />
     <Compile Include="Acceptance\UserGroupsTests.cs" />
     <Compile Include="Acceptance\PostsTests.cs" />
     <Compile Include="Acceptance\AcceptanceTestsBase.cs" />
@@ -162,6 +163,7 @@
     <EmbeddedResource Include="Acceptance\Fixtures\Posts\Responses\PutWithToManyHomogeneousDataUpdateResponse.json" />
     <EmbeddedResource Include="Acceptance\Fixtures\Posts\Responses\PutWithToManyEmptyDataUpdateResponse.json" />
     <EmbeddedResource Include="Acceptance\Fixtures\Posts\Requests\PutWithToManyEmptyDataUpdateRequest.json" />
+    <EmbeddedResource Include="Acceptance\Fixtures\Heterogeneous\Responses\GetSearchResultsResponse.json" />
     <None Include="App.Config">
       <SubType>Designer</SubType>
     </None>

--- a/JSONAPI.Tests/Data/AttributeSerializationTest.json
+++ b/JSONAPI.Tests/Data/AttributeSerializationTest.json
@@ -1,9 +1,10 @@
 {
     "samples": [
         {
+            "type": "samples",
             "id": "1",
             "booleanField": false,
-            "nullableBooleanField":  false,
+            "nullableBooleanField": false,
             "sByteField": 0,
             "nullableSByteField": null,
             "byteField": 0,
@@ -36,6 +37,7 @@
             "enumField": 0,
             "nullableEnumField": null
         }, {
+            "type": "samples",
             "id": "2",
             "booleanField": true,
             "nullableBooleanField": true,

--- a/JSONAPI.Tests/Data/AttributeSerializationTest.json
+++ b/JSONAPI.Tests/Data/AttributeSerializationTest.json
@@ -1,5 +1,5 @@
 {
-    "samples": [
+    "data": [
         {
             "type": "samples",
             "id": "1",

--- a/JSONAPI.Tests/Data/ByteIdSerializationTest.json
+++ b/JSONAPI.Tests/Data/ByteIdSerializationTest.json
@@ -1,12 +1,15 @@
 {
     "tags": [
         {
+            "type": "tags",
             "id": "1",
             "text":  "Ember"
         }, {
+            "type": "tags",
             "id": "2",
             "text":  "React"
         }, {
+            "type": "tags",
             "id": "3",
             "text":  "Angular"
         }

--- a/JSONAPI.Tests/Data/ByteIdSerializationTest.json
+++ b/JSONAPI.Tests/Data/ByteIdSerializationTest.json
@@ -1,5 +1,5 @@
 {
-    "tags": [
+    "data": [
         {
             "type": "tags",
             "id": "1",

--- a/JSONAPI.Tests/Data/DeserializeAttributeRequest.json
+++ b/JSONAPI.Tests/Data/DeserializeAttributeRequest.json
@@ -1,5 +1,5 @@
 {
-    "samples": [
+    "data": [
         {
             "id": "1",
             "booleanField": false,

--- a/JSONAPI.Tests/Data/DeserializeCollectionRequest.json
+++ b/JSONAPI.Tests/Data/DeserializeCollectionRequest.json
@@ -1,5 +1,5 @@
 {
-    "posts": [
+    "data": [
         {
             "id": "1",
             "title": "Linkbait!",

--- a/JSONAPI.Tests/Data/DeserializeRawJsonTest.json
+++ b/JSONAPI.Tests/Data/DeserializeRawJsonTest.json
@@ -1,5 +1,5 @@
 {
-    "comments": [
+    "data": [
         {
             "id": "2",
             "customData": null

--- a/JSONAPI.Tests/Data/LinkTemplateTest.json
+++ b/JSONAPI.Tests/Data/LinkTemplateTest.json
@@ -1,5 +1,6 @@
 {
     "posts": {
+        "type": "posts",
         "id": "2",
         "title": "How to fry an egg",
         "links": {

--- a/JSONAPI.Tests/Data/LinkTemplateTest.json
+++ b/JSONAPI.Tests/Data/LinkTemplateTest.json
@@ -1,5 +1,5 @@
 {
-    "posts": {
+    "data": {
         "type": "posts",
         "id": "2",
         "title": "How to fry an egg",

--- a/JSONAPI.Tests/Data/MalformedRawJsonString.json
+++ b/JSONAPI.Tests/Data/MalformedRawJsonString.json
@@ -1,11 +1,12 @@
 {
     "comments": [
         {
+            "type": "comments",
             "id": "5",
             "body": null,
             "customData": { },
-            "links": { 
-                "post":  null
+            "links": {
+                "post": null
             }
         }
     ]

--- a/JSONAPI.Tests/Data/MalformedRawJsonString.json
+++ b/JSONAPI.Tests/Data/MalformedRawJsonString.json
@@ -1,5 +1,5 @@
 {
-    "comments": [
+    "data": [
         {
             "type": "comments",
             "id": "5",

--- a/JSONAPI.Tests/Data/MetadataManagerPropertyWasPresentRequest.json
+++ b/JSONAPI.Tests/Data/MetadataManagerPropertyWasPresentRequest.json
@@ -1,5 +1,6 @@
 {
-    "posts": {
+    "data": {
+        "type": "posts",
         "id": "42",
         "links": {
             "author": {

--- a/JSONAPI.Tests/Data/NonStandardIdTest.json
+++ b/JSONAPI.Tests/Data/NonStandardIdTest.json
@@ -1,5 +1,5 @@
 ﻿{
-    "non-standard-id-things": [
+    "data": [
         {
             "type": "non-standard-id-things",
             "id": "0657fd6d-a4ab-43c4-84e5-0933c84b4f4f",

--- a/JSONAPI.Tests/Data/NonStandardIdTest.json
+++ b/JSONAPI.Tests/Data/NonStandardIdTest.json
@@ -1,6 +1,7 @@
 ﻿{
     "non-standard-id-things": [
         {
+            "type": "non-standard-id-things",
             "id": "0657fd6d-a4ab-43c4-84e5-0933c84b4f4f",
             "uuid": "0657fd6d-a4ab-43c4-84e5-0933c84b4f4f",
             "data":  "Swap"

--- a/JSONAPI.Tests/Data/ReformatsRawJsonStringWithUnquotedKeys.json
+++ b/JSONAPI.Tests/Data/ReformatsRawJsonStringWithUnquotedKeys.json
@@ -1,5 +1,5 @@
 {
-    "comments": [
+    "data": [
         {
             "type": "comments",
             "id": "5",

--- a/JSONAPI.Tests/Data/ReformatsRawJsonStringWithUnquotedKeys.json
+++ b/JSONAPI.Tests/Data/ReformatsRawJsonStringWithUnquotedKeys.json
@@ -1,10 +1,11 @@
 {
     "comments": [
         {
+            "type": "comments",
             "id": "5",
             "body": null,
-            "customData": { 
-                "unquotedKey":  5
+            "customData": {
+                "unquotedKey": 5
             },
             "links": {
                 "post": null

--- a/JSONAPI.Tests/Data/SerializerIntegrationTest.json
+++ b/JSONAPI.Tests/Data/SerializerIntegrationTest.json
@@ -1,6 +1,7 @@
 {
     "posts": [
         {
+            "type": "posts",
             "id": "1",
             "title": "Linkbait!",
             "links": {
@@ -9,6 +10,7 @@
             }
         },
         {
+            "type": "posts",
             "id": "2",
             "title": "Rant #1023",
             "links": {
@@ -17,6 +19,7 @@
             }
         },
         {
+            "type": "posts",
             "id": "3",
             "title": "Polemic in E-flat minor #824",
             "links": {
@@ -25,6 +28,7 @@
             }
         },
         {
+            "type": "posts",
             "id": "4",
             "title": "This post has no author.",
             "links": {
@@ -36,12 +40,14 @@
     "linked": {
         "comments": [
             {
+                "type": "comments",
                 "id": "2",
                 "body": "Nuh uh!",
                 "customData": null,
                 "links": { "post": "1" }
             },
             {
+                "type": "comments",
                 "id": "3",
                 "body": "Yeah huh!",
                 "customData": null,
@@ -50,6 +56,7 @@
                 }
             },
             {
+                "type": "comments",
                 "id": "4",
                 "body": "Third Reich.",
                 "customData": {
@@ -60,6 +67,7 @@
                 }
             },
             {
+                "type": "comments",
                 "id": "5",
                 "body": "I laughed, I cried!",
                 "customData": null,
@@ -70,6 +78,7 @@
         ],
         "authors": [
             {
+                "type": "authors",
                 "id": "1",
                 "name": "Jason Hater",
                 "links": {

--- a/JSONAPI.Tests/Data/SerializerIntegrationTest.json
+++ b/JSONAPI.Tests/Data/SerializerIntegrationTest.json
@@ -1,5 +1,5 @@
 {
-    "posts": [
+    "data": [
         {
             "type": "posts",
             "id": "1",

--- a/JSONAPI.Tests/Json/JsonApiMediaFormatterTests.cs
+++ b/JSONAPI.Tests/Json/JsonApiMediaFormatterTests.cs
@@ -460,7 +460,7 @@ namespace JSONAPI.Tests.Json
             var formatter = new JsonApiFormatter(modelManager);
             MemoryStream stream = new MemoryStream();
 
-            stream = new MemoryStream(System.Text.Encoding.ASCII.GetBytes(@"{""authors"":{""id"":13,""name"":""Jason Hater"",""bogus"":""PANIC!"",""links"":{""posts"":{""type"": ""posts"",""ids"": []}}}"));
+            stream = new MemoryStream(System.Text.Encoding.ASCII.GetBytes(@"{""data"":{""id"":13,""name"":""Jason Hater"",""bogus"":""PANIC!"",""links"":{""posts"":{""type"": ""posts"",""ids"": []}}}"));
 
             // Act
             Author a;
@@ -480,7 +480,7 @@ namespace JSONAPI.Tests.Json
             var formatter = new JsonApiFormatter(modelManager);
             MemoryStream stream = new MemoryStream();
 
-            stream = new MemoryStream(System.Text.Encoding.ASCII.GetBytes(@"{""authors"":{""id"":13,""name"":""Jason Hater"",""links"":{""posts"":{""type"": ""posts"",""ids"": []},""bogus"":[""PANIC!""]}}}"));
+            stream = new MemoryStream(System.Text.Encoding.ASCII.GetBytes(@"{""data"":{""id"":13,""name"":""Jason Hater"",""links"":{""posts"":{""type"": ""posts"",""ids"": []},""bogus"":[""PANIC!""]}}}"));
 
             // Act
             Author a;

--- a/JSONAPI.TodoMVC.API/Startup.cs
+++ b/JSONAPI.TodoMVC.API/Startup.cs
@@ -7,6 +7,7 @@ using JSONAPI.Http;
 using JSONAPI.Json;
 using JSONAPI.TodoMVC.API.Models;
 using Owin;
+using PluralizationService = JSONAPI.Core.PluralizationService;
 
 namespace JSONAPI.TodoMVC.API
 {

--- a/JSONAPI/Json/JsonApiFormatter.cs
+++ b/JSONAPI/Json/JsonApiFormatter.cs
@@ -88,6 +88,8 @@ namespace JSONAPI.Json
             return true;
         }
 
+        private const string PrimaryDataKeyName = "data";
+
         #region Serialization
 
         public override Task WriteToStreamAsync(System.Type type, object value, Stream writeStream, System.Net.Http.HttpContent content, System.Net.TransportContext transportContext)
@@ -123,10 +125,8 @@ namespace JSONAPI.Json
 
                 //writer.Formatting = Formatting.Indented;
 
-                var root = _modelManager.GetResourceTypeNameForType(type);
-
                 writer.WriteStartObject();
-                writer.WritePropertyName(root);
+                writer.WritePropertyName(PrimaryDataKeyName);
                 if (_modelManager.IsSerializedAsMany(value.GetType()))
                     this.SerializeMany(value, writeStream, writer, serializer, aggregator);
                 else
@@ -501,7 +501,6 @@ namespace JSONAPI.Json
         {
             object retval = null;
             Type singleType = GetSingleType(type);
-            var pripropname = _modelManager.GetResourceTypeNameForType(type);
             var contentHeaders = content == null ? null : content.Headers;
 
             // If content length is 0 then return default value for this type
@@ -520,6 +519,7 @@ namespace JSONAPI.Json
                 if (reader.TokenType != JsonToken.StartObject)
                     throw new JsonSerializationException("Document root is not an object!");
 
+                bool foundPrimaryData = false;
                 while (reader.Read())
                 {
                     if (reader.TokenType == JsonToken.PropertyName)
@@ -536,42 +536,20 @@ namespace JSONAPI.Json
                                 // ignore this, is it even meaningful in a PUT/POST body?
                                 reader.Skip();
                                 break;
-                            default:
-                                if (value == pripropname)
-                                {
-                                    // Could be a single resource or multiple, according to spec!
-                                    if (reader.TokenType == JsonToken.StartArray)
-                                    {
-                                        Type listType = (typeof (List<>)).MakeGenericType(singleType);
-                                        retval = (IList) Activator.CreateInstance(listType);
-                                        reader.Read(); // Burn off StartArray token
-                                        while (reader.TokenType == JsonToken.StartObject)
-                                        {
-                                            ((IList) retval).Add(Deserialize(singleType, reader));
-                                        }
-                                        // burn EndArray token...
-                                        if (reader.TokenType != JsonToken.EndArray)
-                                            throw new JsonReaderException(
-                                                String.Format("Expected JsonToken.EndArray but got {0}",
-                                                    reader.TokenType));
-                                        reader.Read();
-                                    }
-                                    else
-                                    {
-                                        // Because we choose what to deserialize based on the ApiController method signature
-                                        // (not choose the method signature based on what we're deserializing), the `type`
-                                        // parameter will always be `IList<Model>` even if a single model is sent!
-                                        retval = Deserialize(singleType, reader);
-                                    }
-                                }
-                                else
-                                    reader.Skip();
+                            case PrimaryDataKeyName:
+                                // Could be a single resource or multiple, according to spec!
+                                foundPrimaryData = true;
+                                retval = DeserializePrimaryData(singleType, reader);
                                 break;
                         }
                     }
                     else
                         reader.Skip();
                 }
+
+                if (!foundPrimaryData)
+                    throw new BadRequestException(String.Format("Expected primary data located at the `{0}` key", PrimaryDataKeyName));
+
 
                 /* WARNING: May transform a single object into a list of objects!!!
                  * This is a necessary workaround to support POST and PUT of multiple 
@@ -655,6 +633,40 @@ namespace JSONAPI.Json
              */
 
             return GetDefaultValueForType(type);
+        }
+
+        private object DeserializePrimaryData(Type singleType, JsonReader reader)
+        {
+            object retval;
+            if (reader.TokenType == JsonToken.StartArray)
+            {
+                Type listType = (typeof(List<>)).MakeGenericType(singleType);
+                retval = (IList)Activator.CreateInstance(listType);
+                reader.Read(); // Burn off StartArray token
+                while (reader.TokenType == JsonToken.StartObject)
+                {
+                    ((IList)retval).Add(Deserialize(singleType, reader));
+                }
+                // burn EndArray token...
+                if (reader.TokenType != JsonToken.EndArray)
+                    throw new JsonReaderException(
+                        String.Format("Expected JsonToken.EndArray but got {0}",
+                            reader.TokenType));
+                reader.Read();
+            }
+            else if (reader.TokenType == JsonToken.StartObject)
+            {
+                // Because we choose what to deserialize based on the ApiController method signature
+                // (not choose the method signature based on what we're deserializing), the `type`
+                // parameter will always be `IList<Model>` even if a single model is sent!
+                retval = Deserialize(singleType, reader);
+            }
+            else
+            {
+                throw new BadRequestException(String.Format("Unexpected value for the `{0}` key", PrimaryDataKeyName));
+            }
+
+            return retval;
         }
 
         private object Deserialize(Type objectType, JsonReader reader)

--- a/JSONAPI/Json/JsonApiFormatter.cs
+++ b/JSONAPI/Json/JsonApiFormatter.cs
@@ -167,16 +167,16 @@ namespace JSONAPI.Json
         {
             writer.WriteStartObject();
 
-            // The spec no longer requires that the ID key be "id":
-            //     "An ID SHOULD be represented by an 'id' key..." :-/
-            // But Ember Data does. So, we'll add "id" to the document
-            // always, and also serialize the property under its given
-            // name, for now at least.
-            //TODO: Partly because of this, we should probably disallow updates to Id properties where practical.
+            var resourceType = value.GetType();
+
+            // Write the type
+            writer.WritePropertyName("type");
+            var jsonTypeKey = _modelManager.GetResourceTypeNameForType(resourceType);
+            writer.WriteValue(jsonTypeKey);
 
             // Do the Id now...
             writer.WritePropertyName("id");
-            var idProp = _modelManager.GetIdProperty(value.GetType());
+            var idProp = _modelManager.GetIdProperty(resourceType);
             writer.WriteValue(GetValueForIdProperty(idProp, value));
 
             // Leverage the cached map to avoid another costly call to System.Type.GetProperties()


### PR DESCRIPTION
This PR requires #80 to be merged first.

This brings us closer to compliance with the RC2 spec by

1. Prefixing primary data at the `data` key instead of at the resource type name, e.g. `posts` or `comments`.
2. Including a `type` key in all resource objects.