### PR TITLE
Model manager changes

### DIFF
--- a/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Heterogeneous/Responses/GetSearchResultsResponse.json
+++ b/JSONAPI.EntityFramework.Tests/Acceptance/Fixtures/Heterogeneous/Responses/GetSearchResultsResponse.json
@@ -18,8 +18,8 @@
             "text": "Comment 1",
             "created": "2015-01-31T14:30:00+00:00",
             "links": { 
-                "author": "403",
-                "post": "201"
+                "post": "201",
+                "author": "403"
             }
         }
     ]

--- a/JSONAPI.Tests/ActionFilters/EnableFilteringAttributeTests.cs
+++ b/JSONAPI.Tests/ActionFilters/EnableFilteringAttributeTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Formatting;
+using System.Web.Http;
 using System.Web.Http.Controllers;
 using System.Web.Http.Filters;
 using FluentAssertions;
@@ -563,6 +564,8 @@ namespace JSONAPI.Tests.ActionFilters
         private T[] GetArray<T>(string uri)
         {
             var modelManager = new ModelManager(new PluralizationService());
+            modelManager.RegisterResourceType(typeof(Dummy));
+            modelManager.RegisterResourceType(typeof(RelatedItemWithId));
 
             var filter = new EnableFilteringAttribute(modelManager);
 
@@ -1130,8 +1133,8 @@ namespace JSONAPI.Tests.ActionFilters
         [TestMethod]
         public void Does_not_filter_unknown_type()
         {
-            var returnedArray = GetArray<Dummy>("http://api.example.com/dummies?unknownTypeField=asdfasd");
-            returnedArray.Length.Should().Be(_fixtures.Count);
+            Action action = () => GetArray<Dummy>("http://api.example.com/dummies?unknownTypeField=asdfasd");
+            action.ShouldThrow<HttpResponseException>().Which.Response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         }
 
         #endregion

--- a/JSONAPI.Tests/Core/MetadataManagerTests.cs
+++ b/JSONAPI.Tests/Core/MetadataManagerTests.cs
@@ -18,6 +18,7 @@ namespace JSONAPI.Tests.Core
                 // Arrange
                 var modelManager = new ModelManager(new PluralizationService());
                 modelManager.RegisterResourceType(typeof(Post));
+                modelManager.RegisterResourceType(typeof(Author));
                 JsonApiFormatter formatter = new JsonApiFormatter(modelManager);
 
                 var p = (Post) formatter.ReadFromStreamAsync(typeof(Post), inputStream, null, null).Result;

--- a/JSONAPI.Tests/Core/ModelManagerTests.cs
+++ b/JSONAPI.Tests/Core/ModelManagerTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using JSONAPI.Attributes;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using JSONAPI.Core;
 using JSONAPI.Tests.Models;
@@ -6,6 +7,7 @@ using System.Reflection;
 using System.Collections.Generic;
 using System.Collections;
 using FluentAssertions;
+using Newtonsoft.Json;
 
 namespace JSONAPI.Tests.Core
 {
@@ -19,7 +21,7 @@ namespace JSONAPI.Tests.Core
 
         private class CustomIdModel
         {
-            [JSONAPI.Attributes.UseAsId]
+            [UseAsId]
             public Guid Uuid { get; set; }
 
             public string Data { get; set; }
@@ -28,6 +30,26 @@ namespace JSONAPI.Tests.Core
         private class DerivedPost : Post
         {
             
+        }
+
+        private class Band
+        {
+            [UseAsId]
+            public string BandName { get; set; }
+
+            [JsonProperty("THE-GENRE")]
+            public string Genre { get; set; }
+        }
+
+        private class Salad
+        {
+            public string Id { get; set; }
+
+            [JsonProperty("salad-type")]
+            public string TheSaladType { get; set; }
+
+            [JsonProperty("salad-type")]
+            public string AnotherSaladType { get; set; }
         }
 
         [TestMethod]
@@ -56,7 +78,7 @@ namespace JSONAPI.Tests.Core
             // Assert
             action.ShouldThrow<InvalidOperationException>()
                 .Which.Message.Should()
-                .Be("Unable to determine Id property for type JSONAPI.Tests.Core.ModelManagerTests+InvalidModel");
+                .Be("Unable to determine Id property for type `invalid-models`.");
         }
 
         [TestMethod]
@@ -180,9 +202,9 @@ namespace JSONAPI.Tests.Core
             var mm = new ModelManager(pluralizationService);
 
             // Act
-            var idKey = mm.GetJsonKeyForProperty(typeof(Author).GetProperty("Id"));
-            var nameKey = mm.GetJsonKeyForProperty(typeof(Author).GetProperty("Name"));
-            var postsKey = mm.GetJsonKeyForProperty(typeof(Author).GetProperty("Posts"));
+            var idKey = mm.CalculateJsonKeyForProperty(typeof(Author).GetProperty("Id"));
+            var nameKey = mm.CalculateJsonKeyForProperty(typeof(Author).GetProperty("Name"));
+            var postsKey = mm.CalculateJsonKeyForProperty(typeof(Author).GetProperty("Posts"));
 
             // Assert
             Assert.AreEqual("id", idKey);
@@ -214,6 +236,54 @@ namespace JSONAPI.Tests.Core
 
             postsProp.Property.Should().BeSameAs(authorType.GetProperty("Posts"));
             postsProp.Should().BeOfType<RelationshipModelProperty>();
+        }
+
+        [TestMethod]
+        public void GetPropertyForJsonKey_returns_correct_value_for_custom_id()
+        {
+            // Arrange
+            var pluralizationService = new PluralizationService();
+            var mm = new ModelManager(pluralizationService);
+            Type bandType = typeof(Band);
+            mm.RegisterResourceType(bandType);
+
+            // Act
+            var idProp = mm.GetPropertyForJsonKey(bandType, "id");
+
+            // Assert
+            idProp.Property.Should().BeSameAs(bandType.GetProperty("BandName"));
+            idProp.Should().BeOfType<FieldModelProperty>();
+        }
+
+        [TestMethod]
+        public void GetPropertyForJsonKey_returns_correct_value_for_JsonProperty_attribute()
+        {
+            // Arrange
+            var pluralizationService = new PluralizationService();
+            var mm = new ModelManager(pluralizationService);
+            Type bandType = typeof(Band);
+            mm.RegisterResourceType(bandType);
+
+            // Act
+            var prop = mm.GetPropertyForJsonKey(bandType, "THE-GENRE");
+
+            // Assert
+            prop.Property.Should().BeSameAs(bandType.GetProperty("Genre"));
+            prop.Should().BeOfType<FieldModelProperty>();
+        }
+
+        [TestMethod]
+        public void Cant_register_type_with_two_properties_with_the_same_name()
+        {
+            var pluralizationService = new PluralizationService();
+            var mm = new ModelManager(pluralizationService);
+            Type saladType = typeof(Salad);
+
+            // Act
+            Action action = () => mm.RegisterResourceType(saladType);
+
+            // Assert
+            action.ShouldThrow<InvalidOperationException>().Which.Message.Should().Be("The type `salads` already contains a property keyed at `salad-type`.");
         }
 
         [TestMethod]

--- a/JSONAPI.Tests/Data/NonStandardIdTest.json
+++ b/JSONAPI.Tests/Data/NonStandardIdTest.json
@@ -3,7 +3,6 @@
         {
             "type": "non-standard-id-things",
             "id": "0657fd6d-a4ab-43c4-84e5-0933c84b4f4f",
-            "uuid": "0657fd6d-a4ab-43c4-84e5-0933c84b4f4f",
             "data":  "Swap"
         }
     ]

--- a/JSONAPI.Tests/Json/JsonApiMediaFormatterTests.cs
+++ b/JSONAPI.Tests/Json/JsonApiMediaFormatterTests.cs
@@ -392,6 +392,8 @@ namespace JSONAPI.Tests.Json
                 // Arrange
                 var modelManager = new ModelManager(new PluralizationService());
                 modelManager.RegisterResourceType(typeof(Post));
+                modelManager.RegisterResourceType(typeof(Author));
+                modelManager.RegisterResourceType(typeof(Comment));
                 var formatter = new JsonApiFormatter(modelManager);
 
                 // Act
@@ -536,7 +538,7 @@ namespace JSONAPI.Tests.Json
 
         [TestMethod]
         [DeploymentItem(@"Data\NonStandardIdTest.json")]
-        public void DeserializeNonStandardIdWithIdOnly()
+        public void DeserializeNonStandardId()
         {
             var modelManager = new ModelManager(new PluralizationService());
             modelManager.RegisterResourceType(typeof(NonStandardIdThing));
@@ -553,28 +555,6 @@ namespace JSONAPI.Tests.Json
             json.Should().NotContain("uuid", "The \"uuid\" attribute was supposed to be removed, test methodology problem!");
             things.Count.Should().Be(1);
             things.First().Uuid.Should().Be(new Guid("0657fd6d-a4ab-43c4-84e5-0933c84b4f4f"));
-        }
-
-        [TestMethod]
-        [DeploymentItem(@"Data\NonStandardIdTest.json")]
-        public void DeserializeNonStandardIdWithoutId()
-        {
-            var modelManager = new ModelManager(new PluralizationService());
-            modelManager.RegisterResourceType(typeof(NonStandardIdThing));
-            var formatter = new JsonApiFormatter(modelManager);
-            string json = File.ReadAllText("NonStandardIdTest.json");
-            json = Regex.Replace(json, @"""id"":\s*""0657fd6d-a4ab-43c4-84e5-0933c84b4f4f""\s*,", ""); // remove the uuid attribute
-            var stream = new MemoryStream(System.Text.Encoding.ASCII.GetBytes(json));
-
-            // Act
-            IList<NonStandardIdThing> things;
-            things = (IList<NonStandardIdThing>)formatter.ReadFromStreamAsync(typeof(NonStandardIdThing), stream, (System.Net.Http.HttpContent)null, (System.Net.Http.Formatting.IFormatterLogger)null).Result;
-
-            // Assert
-            json.Should().NotContain("\"id\"", "The \"id\" attribute was supposed to be removed, test methodology problem!");
-            things.Count.Should().Be(1);
-            things.First().Uuid.Should().Be(new Guid("0657fd6d-a4ab-43c4-84e5-0933c84b4f4f"));
-
         }
     
         #endregion

--- a/JSONAPI.Tests/Json/LinkTemplateTests.cs
+++ b/JSONAPI.Tests/Json/LinkTemplateTests.cs
@@ -52,6 +52,7 @@ namespace JSONAPI.Tests.Json
         {
             var modelManager = new ModelManager(new PluralizationService());
             modelManager.RegisterResourceType(typeof(Post));
+            modelManager.RegisterResourceType(typeof(User));
             var formatter = new JsonApiFormatter(modelManager);
             var stream = new MemoryStream();
 

--- a/JSONAPI/ActionFilters/EnableFilteringAttribute.cs
+++ b/JSONAPI/ActionFilters/EnableFilteringAttribute.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Net;
 using System.Net.Http;
 using System.Reflection;
+using System.Web.Http;
 using System.Web.Http.Filters;
 using JSONAPI.Core;
 
@@ -72,333 +74,339 @@ namespace JSONAPI.ActionFilters
                 if (String.IsNullOrWhiteSpace(queryPair.Key))
                     continue;
 
-                var prop = _modelManager.GetPropertyForJsonKey(type, queryPair.Key);
-
-                if (prop != null)
+                ModelProperty modelProperty;
+                try
                 {
-                    var propertyType = prop.PropertyType;
-
-                    var queryValue = queryPair.Value;
-                    if (string.IsNullOrWhiteSpace(queryValue))
-                        queryValue = null;
-
-                    Expression expr = null;
-                    if (propertyType == typeof (String))
-                    {
-                        if (String.IsNullOrWhiteSpace(queryValue))
-                        {
-                            Expression propertyExpr = Expression.Property(param, prop);
-                            expr = Expression.Equal(propertyExpr, Expression.Constant(null));
-                        }
-                        else
-                        {
-                            Expression propertyExpr = Expression.Property(param, prop);
-                            expr = Expression.Equal(propertyExpr, Expression.Constant(queryValue));
-                        }
-                    }
-                    else if (propertyType == typeof(Boolean))
-                    {
-                        bool value;
-                        expr = bool.TryParse(queryValue, out value)
-                            ? GetPropertyExpression(value, prop, param)
-                            : Expression.Constant(false);
-                    }
-                    else if (propertyType == typeof (Boolean?))
-                    {
-                        bool tmp;
-                        var value = bool.TryParse(queryValue, out tmp) ? tmp : (bool?)null;
-                        expr = GetPropertyExpression(value, prop, param);
-                    }
-                    else if (propertyType == typeof(SByte))
-                    {
-                        SByte value;
-                        expr = SByte.TryParse(queryValue, out value)
-                            ? GetPropertyExpression(value, prop, param)
-                            : Expression.Constant(false);
-                    }
-                    else if (propertyType == typeof (SByte?))
-                    {
-                        SByte tmp;
-                        var value = SByte.TryParse(queryValue, out tmp) ? tmp : (SByte?)null;
-                        expr = GetPropertyExpression(value, prop, param);
-                    }
-                    else if (propertyType == typeof(Byte))
-                    {
-                        Byte value;
-                        expr = Byte.TryParse(queryValue, out value)
-                            ? GetPropertyExpression(value, prop, param)
-                            : Expression.Constant(false);
-                    }
-                    else if (propertyType == typeof(Byte?))
-                    {
-                        Byte tmp;
-                        var value = Byte.TryParse(queryValue, out tmp) ? tmp : (Byte?)null;
-                        expr = GetPropertyExpression(value, prop, param);
-                    }
-                    else if (propertyType == typeof(Int16))
-                    {
-                        Int16 value;
-                        expr = Int16.TryParse(queryValue, out value)
-                            ? GetPropertyExpression(value, prop, param)
-                            : Expression.Constant(false);
-                    }
-                    else if (propertyType == typeof(Int16?))
-                    {
-                        Int16 tmp;
-                        var value = Int16.TryParse(queryValue, out tmp) ? tmp : (Int16?)null;
-                        expr = GetPropertyExpression(value, prop, param);
-                    }
-                    else if (propertyType == typeof(UInt16))
-                    {
-                        UInt16 value;
-                        expr = UInt16.TryParse(queryValue, out value)
-                            ? GetPropertyExpression(value, prop, param)
-                            : Expression.Constant(false);
-                    }
-                    else if (propertyType == typeof(UInt16?))
-                    {
-                        UInt16 tmp;
-                        var value = UInt16.TryParse(queryValue, out tmp) ? tmp : (UInt16?)null;
-                        expr = GetPropertyExpression(value, prop, param);
-                    }
-                    else if (propertyType == typeof(Int32))
-                    {
-                        Int32 value;
-                        expr = Int32.TryParse(queryValue, out value)
-                            ? GetPropertyExpression(value, prop, param)
-                            : Expression.Constant(false);
-                    }
-                    else if (propertyType == typeof(Int32?))
-                    {
-                        Int32 tmp;
-                        var value = Int32.TryParse(queryValue, out tmp) ? tmp : (Int32?)null;
-                        expr = GetPropertyExpression(value, prop, param);
-                    }
-                    else if (propertyType == typeof(UInt32))
-                    {
-                        UInt32 value;
-                        expr = UInt32.TryParse(queryValue, out value)
-                            ? GetPropertyExpression(value, prop, param)
-                            : Expression.Constant(false);
-                    }
-                    else if (propertyType == typeof(UInt32?))
-                    {
-                        UInt32 tmp;
-                        var value = UInt32.TryParse(queryValue, out tmp) ? tmp : (UInt32?)null;
-                        expr = GetPropertyExpression(value, prop, param);
-                    }
-                    else if (propertyType == typeof(Int64))
-                    {
-                        Int64 value;
-                        expr = Int64.TryParse(queryValue, out value)
-                            ? GetPropertyExpression(value, prop, param)
-                            : Expression.Constant(false);
-                    }
-                    else if (propertyType == typeof(Int64?))
-                    {
-                        Int64 tmp;
-                        var value = Int64.TryParse(queryValue, out tmp) ? tmp : (Int64?)null;
-                        expr = GetPropertyExpression(value, prop, param);
-                    }
-                    else if (propertyType == typeof(UInt64))
-                    {
-                        UInt64 value;
-                        expr = UInt64.TryParse(queryValue, out value)
-                            ? GetPropertyExpression(value, prop, param)
-                            : Expression.Constant(false);
-                    }
-                    else if (propertyType == typeof(UInt64?))
-                    {
-                        UInt64 tmp;
-                        var value = UInt64.TryParse(queryValue, out tmp) ? tmp : (UInt64?)null;
-                        expr = GetPropertyExpression(value, prop, param);
-                    }
-                    else if (propertyType == typeof(Single))
-                    {
-                        Single value;
-                        expr = Single.TryParse(queryValue, out value)
-                            ? GetPropertyExpression(value, prop, param)
-                            : Expression.Constant(false);
-                    }
-                    else if (propertyType == typeof(Single?))
-                    {
-                        Single tmp;
-                        var value = Single.TryParse(queryValue, out tmp) ? tmp : (Single?)null;
-                        expr = GetPropertyExpression(value, prop, param);
-                    }
-                    else if (propertyType == typeof(Double))
-                    {
-                        Double value;
-                        expr = Double.TryParse(queryValue, out value)
-                            ? GetPropertyExpression(value, prop, param)
-                            : Expression.Constant(false);
-                    }
-                    else if (propertyType == typeof(Double?))
-                    {
-                        Double tmp;
-                        var value = Double.TryParse(queryValue, out tmp) ? tmp : (Double?)null;
-                        expr = GetPropertyExpression(value, prop, param);
-                    }
-                    else if (propertyType == typeof(Decimal))
-                    {
-                        Decimal value;
-                        expr = Decimal.TryParse(queryValue, out value)
-                            ? GetPropertyExpression(value, prop, param)
-                            : Expression.Constant(false);
-                    }
-                    else if (propertyType == typeof(Decimal?))
-                    {
-                        Decimal tmp;
-                        var value = Decimal.TryParse(queryValue, out tmp) ? tmp : (Decimal?)null;
-                        expr = GetPropertyExpression(value, prop, param);
-                    }
-                    else if (propertyType == typeof(DateTime))
-                    {
-                        DateTime value;
-                        expr = DateTime.TryParse(queryValue, out value)
-                            ? GetPropertyExpression(value, prop, param)
-                            : Expression.Constant(false);
-                    }
-                    else if (propertyType == typeof(DateTime?))
-                    {
-                        DateTime tmp;
-                        var value = DateTime.TryParse(queryValue, out tmp) ? tmp : (DateTime?)null;
-                        expr = GetPropertyExpression(value, prop, param);
-                    }
-                    else if (propertyType == typeof(DateTimeOffset))
-                    {
-                        DateTimeOffset value;
-                        expr = DateTimeOffset.TryParse(queryValue, out value)
-                            ? GetPropertyExpression<DateTimeOffset>(value, prop, param)
-                            : Expression.Constant(false);
-                    }
-                    else if (propertyType == typeof (DateTimeOffset?))
-                    {
-                        DateTimeOffset tmp;
-                        var value = DateTimeOffset.TryParse(queryValue, out tmp) ? tmp : (DateTimeOffset?)null;
-                        expr = GetPropertyExpression(value, prop, param);
-                    }
-                    else if (propertyType.IsEnum)
-                    {
-                        int value;
-                        expr = (int.TryParse(queryValue, out value) && Enum.IsDefined(propertyType, value))
-                            ? GetEnumPropertyExpression(value, prop, param)
-                            : Expression.Constant(false);
-                    }
-                    else if (propertyType.IsGenericType && propertyType.GetGenericTypeDefinition() == typeof (Nullable<>) &&
-                             propertyType.GenericTypeArguments[0].IsEnum)
-                    {
-                        int tmp;
-                        var value = int.TryParse(queryValue, out tmp) ? tmp : (int?)null;
-                        expr = GetEnumPropertyExpression(value, prop, param);
-                    }
-                    else
-                    {
-                        // See if it is a relationship property
-                        if (_modelManager.IsSerializedAsMany(propertyType))
-                        {
-                            var elementType = _modelManager.GetElementType(propertyType);
-                            PropertyInfo relatedIdProperty;
-                            try
-                            {
-                                relatedIdProperty = _modelManager.GetIdProperty(elementType);
-                            }
-                            catch (InvalidOperationException)
-                            {
-                                relatedIdProperty = null;
-                            }
-
-                            if (relatedIdProperty != null)
-                            {
-                                var propertyExpr = Expression.Property(param, prop);
-
-                                if (string.IsNullOrWhiteSpace(queryValue))
-                                {
-                                    var leftExpr = Expression.Equal(propertyExpr, Expression.Constant(null));
-
-                                    var asQueryableCallExpr = Expression.Call(
-                                        typeof(Queryable),
-                                        "AsQueryable",
-                                        new[] { elementType },
-                                        propertyExpr);
-                                    var anyCallExpr = Expression.Call(
-                                        typeof(Queryable),
-                                        "Any",
-                                        new[] { elementType },
-                                        asQueryableCallExpr);
-                                    var rightExpr = Expression.Not(anyCallExpr);
-
-                                    expr = Expression.OrElse(leftExpr, rightExpr);
-                                }
-                                else
-                                {
-                                    var leftExpr = Expression.NotEqual(propertyExpr, Expression.Constant(null));
-
-                                    var idValue = queryValue.Trim();
-                                    var idExpr = Expression.Constant(idValue);
-                                    var anyParam = Expression.Parameter(elementType);
-                                    var relatedIdPropertyExpr = Expression.Property(anyParam, relatedIdProperty);
-                                    var relatedIdPropertyEqualsIdExpr = Expression.Equal(relatedIdPropertyExpr, idExpr);
-                                    var anyPredicateExpr = Expression.Lambda(relatedIdPropertyEqualsIdExpr, anyParam);
-                                    var asQueryableCallExpr = Expression.Call(
-                                        typeof(Queryable),
-                                        "AsQueryable",
-                                        new[] { elementType },
-                                        propertyExpr);
-                                    var rightExpr = Expression.Call(
-                                        typeof(Queryable),
-                                        "Any",
-                                        new[] { elementType },
-                                        asQueryableCallExpr,
-                                        anyPredicateExpr);
-
-                                    expr = Expression.AndAlso(leftExpr, rightExpr);
-                                }
-                            }
-                        }
-                        else
-                        {
-                            PropertyInfo relatedIdProperty;
-                            try
-                            {
-                                relatedIdProperty = _modelManager.GetIdProperty(propertyType);
-                            }
-                            catch (InvalidOperationException)
-                            {
-                                relatedIdProperty = null;
-                            }
-
-                            if (relatedIdProperty != null)
-                            {
-                                var propertyExpr = Expression.Property(param, prop);
-
-                                if (string.IsNullOrWhiteSpace(queryValue))
-                                {
-                                    expr = Expression.Equal(propertyExpr, Expression.Constant(null));
-                                }
-                                else
-                                {
-                                    var leftExpr = Expression.NotEqual(propertyExpr, Expression.Constant(null));
-
-                                    var idValue = queryValue.Trim();
-                                    var idExpr = Expression.Constant(idValue);
-                                    var relatedIdPropertyExpr = Expression.Property(propertyExpr, relatedIdProperty);
-                                    var rightExpr = Expression.Equal(relatedIdPropertyExpr, idExpr);
-
-                                    expr = Expression.AndAlso(leftExpr, rightExpr);
-                                }
-                            }
-                        }
-                    }
-
-                    if (expr == null)
-                        expr = Expression.Constant(true);
-
-                    workingExpr = workingExpr == null ? expr : Expression.AndAlso(workingExpr, expr);
+                    modelProperty = _modelManager.GetPropertyForJsonKey(type, queryPair.Key);
                 }
+                catch (InvalidOperationException)
+                {
+                    throw new HttpResponseException(HttpStatusCode.BadRequest);
+                }
+                
+                var queryValue = queryPair.Value;
+                if (string.IsNullOrWhiteSpace(queryValue))
+                    queryValue = null;
+
+                Expression expr = null;
+
+                // See if it is a field property
+                var fieldModelProperty = modelProperty as FieldModelProperty;
+                if (fieldModelProperty != null)
+                    expr = GetPredicateBodyForField(fieldModelProperty, queryValue, param);
+
+                // See if it is a relationship property
+                var relationshipModelProperty = modelProperty as RelationshipModelProperty;
+                if (relationshipModelProperty != null)
+                    expr = GetPredicateBodyForRelationship(relationshipModelProperty, queryValue, param);
+
+                workingExpr = workingExpr == null ? expr : Expression.AndAlso(workingExpr, expr);
             }
 
             return workingExpr ?? Expression.Constant(true); // No filters, so return everything
+        }
+
+        private Expression GetPredicateBodyForField(FieldModelProperty modelProperty, string queryValue, ParameterExpression param)
+        {
+            var prop = modelProperty.Property;
+            var propertyType = prop.PropertyType;
+
+            Expression expr;
+            if (propertyType == typeof(String))
+            {
+                if (String.IsNullOrWhiteSpace(queryValue))
+                {
+                    Expression propertyExpr = Expression.Property(param, prop);
+                    expr = Expression.Equal(propertyExpr, Expression.Constant(null));
+                }
+                else
+                {
+                    Expression propertyExpr = Expression.Property(param, prop);
+                    expr = Expression.Equal(propertyExpr, Expression.Constant(queryValue));
+                }
+            }
+            else if (propertyType == typeof(Boolean))
+            {
+                bool value;
+                expr = bool.TryParse(queryValue, out value)
+                    ? GetPropertyExpression(value, prop, param)
+                    : Expression.Constant(false);
+            }
+            else if (propertyType == typeof(Boolean?))
+            {
+                bool tmp;
+                var value = bool.TryParse(queryValue, out tmp) ? tmp : (bool?)null;
+                expr = GetPropertyExpression(value, prop, param);
+            }
+            else if (propertyType == typeof(SByte))
+            {
+                SByte value;
+                expr = SByte.TryParse(queryValue, out value)
+                    ? GetPropertyExpression(value, prop, param)
+                    : Expression.Constant(false);
+            }
+            else if (propertyType == typeof(SByte?))
+            {
+                SByte tmp;
+                var value = SByte.TryParse(queryValue, out tmp) ? tmp : (SByte?)null;
+                expr = GetPropertyExpression(value, prop, param);
+            }
+            else if (propertyType == typeof(Byte))
+            {
+                Byte value;
+                expr = Byte.TryParse(queryValue, out value)
+                    ? GetPropertyExpression(value, prop, param)
+                    : Expression.Constant(false);
+            }
+            else if (propertyType == typeof(Byte?))
+            {
+                Byte tmp;
+                var value = Byte.TryParse(queryValue, out tmp) ? tmp : (Byte?)null;
+                expr = GetPropertyExpression(value, prop, param);
+            }
+            else if (propertyType == typeof(Int16))
+            {
+                Int16 value;
+                expr = Int16.TryParse(queryValue, out value)
+                    ? GetPropertyExpression(value, prop, param)
+                    : Expression.Constant(false);
+            }
+            else if (propertyType == typeof(Int16?))
+            {
+                Int16 tmp;
+                var value = Int16.TryParse(queryValue, out tmp) ? tmp : (Int16?)null;
+                expr = GetPropertyExpression(value, prop, param);
+            }
+            else if (propertyType == typeof(UInt16))
+            {
+                UInt16 value;
+                expr = UInt16.TryParse(queryValue, out value)
+                    ? GetPropertyExpression(value, prop, param)
+                    : Expression.Constant(false);
+            }
+            else if (propertyType == typeof(UInt16?))
+            {
+                UInt16 tmp;
+                var value = UInt16.TryParse(queryValue, out tmp) ? tmp : (UInt16?)null;
+                expr = GetPropertyExpression(value, prop, param);
+            }
+            else if (propertyType == typeof(Int32))
+            {
+                Int32 value;
+                expr = Int32.TryParse(queryValue, out value)
+                    ? GetPropertyExpression(value, prop, param)
+                    : Expression.Constant(false);
+            }
+            else if (propertyType == typeof(Int32?))
+            {
+                Int32 tmp;
+                var value = Int32.TryParse(queryValue, out tmp) ? tmp : (Int32?)null;
+                expr = GetPropertyExpression(value, prop, param);
+            }
+            else if (propertyType == typeof(UInt32))
+            {
+                UInt32 value;
+                expr = UInt32.TryParse(queryValue, out value)
+                    ? GetPropertyExpression(value, prop, param)
+                    : Expression.Constant(false);
+            }
+            else if (propertyType == typeof(UInt32?))
+            {
+                UInt32 tmp;
+                var value = UInt32.TryParse(queryValue, out tmp) ? tmp : (UInt32?)null;
+                expr = GetPropertyExpression(value, prop, param);
+            }
+            else if (propertyType == typeof(Int64))
+            {
+                Int64 value;
+                expr = Int64.TryParse(queryValue, out value)
+                    ? GetPropertyExpression(value, prop, param)
+                    : Expression.Constant(false);
+            }
+            else if (propertyType == typeof(Int64?))
+            {
+                Int64 tmp;
+                var value = Int64.TryParse(queryValue, out tmp) ? tmp : (Int64?)null;
+                expr = GetPropertyExpression(value, prop, param);
+            }
+            else if (propertyType == typeof(UInt64))
+            {
+                UInt64 value;
+                expr = UInt64.TryParse(queryValue, out value)
+                    ? GetPropertyExpression(value, prop, param)
+                    : Expression.Constant(false);
+            }
+            else if (propertyType == typeof(UInt64?))
+            {
+                UInt64 tmp;
+                var value = UInt64.TryParse(queryValue, out tmp) ? tmp : (UInt64?)null;
+                expr = GetPropertyExpression(value, prop, param);
+            }
+            else if (propertyType == typeof(Single))
+            {
+                Single value;
+                expr = Single.TryParse(queryValue, out value)
+                    ? GetPropertyExpression(value, prop, param)
+                    : Expression.Constant(false);
+            }
+            else if (propertyType == typeof(Single?))
+            {
+                Single tmp;
+                var value = Single.TryParse(queryValue, out tmp) ? tmp : (Single?)null;
+                expr = GetPropertyExpression(value, prop, param);
+            }
+            else if (propertyType == typeof(Double))
+            {
+                Double value;
+                expr = Double.TryParse(queryValue, out value)
+                    ? GetPropertyExpression(value, prop, param)
+                    : Expression.Constant(false);
+            }
+            else if (propertyType == typeof(Double?))
+            {
+                Double tmp;
+                var value = Double.TryParse(queryValue, out tmp) ? tmp : (Double?)null;
+                expr = GetPropertyExpression(value, prop, param);
+            }
+            else if (propertyType == typeof(Decimal))
+            {
+                Decimal value;
+                expr = Decimal.TryParse(queryValue, out value)
+                    ? GetPropertyExpression(value, prop, param)
+                    : Expression.Constant(false);
+            }
+            else if (propertyType == typeof(Decimal?))
+            {
+                Decimal tmp;
+                var value = Decimal.TryParse(queryValue, out tmp) ? tmp : (Decimal?)null;
+                expr = GetPropertyExpression(value, prop, param);
+            }
+            else if (propertyType == typeof(DateTime))
+            {
+                DateTime value;
+                expr = DateTime.TryParse(queryValue, out value)
+                    ? GetPropertyExpression(value, prop, param)
+                    : Expression.Constant(false);
+            }
+            else if (propertyType == typeof(DateTime?))
+            {
+                DateTime tmp;
+                var value = DateTime.TryParse(queryValue, out tmp) ? tmp : (DateTime?)null;
+                expr = GetPropertyExpression(value, prop, param);
+            }
+            else if (propertyType == typeof(DateTimeOffset))
+            {
+                DateTimeOffset value;
+                expr = DateTimeOffset.TryParse(queryValue, out value)
+                    ? GetPropertyExpression<DateTimeOffset>(value, prop, param)
+                    : Expression.Constant(false);
+            }
+            else if (propertyType == typeof(DateTimeOffset?))
+            {
+                DateTimeOffset tmp;
+                var value = DateTimeOffset.TryParse(queryValue, out tmp) ? tmp : (DateTimeOffset?)null;
+                expr = GetPropertyExpression(value, prop, param);
+            }
+            else if (propertyType.IsEnum)
+            {
+                int value;
+                expr = (int.TryParse(queryValue, out value) && Enum.IsDefined(propertyType, value))
+                    ? GetEnumPropertyExpression(value, prop, param)
+                    : Expression.Constant(false);
+            }
+            else if (propertyType.IsGenericType && propertyType.GetGenericTypeDefinition() == typeof (Nullable<>) &&
+                     propertyType.GenericTypeArguments[0].IsEnum)
+            {
+                int tmp;
+                var value = int.TryParse(queryValue, out tmp) ? tmp : (int?) null;
+                expr = GetEnumPropertyExpression(value, prop, param);
+            }
+            else
+            {
+                expr = Expression.Constant(true);
+            }
+
+            return expr;
+        }
+
+        private Expression GetPredicateBodyForRelationship(RelationshipModelProperty modelProperty, string queryValue, ParameterExpression param)
+        {
+            var relatedType = modelProperty.RelatedType;
+            PropertyInfo relatedIdProperty;
+            try
+            {
+                relatedIdProperty = _modelManager.GetIdProperty(relatedType);
+            }
+            catch (InvalidOperationException)
+            {
+                throw new HttpResponseException(HttpStatusCode.BadRequest);
+            }
+
+            var prop = modelProperty.Property;
+
+            if (modelProperty.IsToMany)
+            {
+                var propertyExpr = Expression.Property(param, prop);
+
+                if (string.IsNullOrWhiteSpace(queryValue))
+                {
+                    var leftExpr = Expression.Equal(propertyExpr, Expression.Constant(null));
+
+                    var asQueryableCallExpr = Expression.Call(
+                        typeof(Queryable),
+                        "AsQueryable",
+                        new[] { relatedType },
+                        propertyExpr);
+                    var anyCallExpr = Expression.Call(
+                        typeof(Queryable),
+                        "Any",
+                        new[] { relatedType },
+                        asQueryableCallExpr);
+                    var rightExpr = Expression.Not(anyCallExpr);
+
+                    return Expression.OrElse(leftExpr, rightExpr);
+                }
+                else
+                {
+                    var leftExpr = Expression.NotEqual(propertyExpr, Expression.Constant(null));
+
+                    var idValue = queryValue.Trim();
+                    var idExpr = Expression.Constant(idValue);
+                    var anyParam = Expression.Parameter(relatedType);
+                    var relatedIdPropertyExpr = Expression.Property(anyParam, relatedIdProperty);
+                    var relatedIdPropertyEqualsIdExpr = Expression.Equal(relatedIdPropertyExpr, idExpr);
+                    var anyPredicateExpr = Expression.Lambda(relatedIdPropertyEqualsIdExpr, anyParam);
+                    var asQueryableCallExpr = Expression.Call(
+                        typeof(Queryable),
+                        "AsQueryable",
+                        new[] { relatedType },
+                        propertyExpr);
+                    var rightExpr = Expression.Call(
+                        typeof(Queryable),
+                        "Any",
+                        new[] { relatedType },
+                        asQueryableCallExpr,
+                        anyPredicateExpr);
+
+                    return Expression.AndAlso(leftExpr, rightExpr);
+                }
+            }
+            else
+            {
+                var propertyExpr = Expression.Property(param, prop);
+
+                if (string.IsNullOrWhiteSpace(queryValue))
+                    return Expression.Equal(propertyExpr, Expression.Constant(null));
+
+                var leftExpr = Expression.NotEqual(propertyExpr, Expression.Constant(null));
+
+                var idValue = queryValue.Trim();
+                var idExpr = Expression.Constant(idValue);
+                var relatedIdPropertyExpr = Expression.Property(propertyExpr, relatedIdProperty);
+                var rightExpr = Expression.Equal(relatedIdPropertyExpr, idExpr);
+
+                return Expression.AndAlso(leftExpr, rightExpr);
+            }
         }
 
         private static Expression GetPropertyExpression<T>(T value, PropertyInfo property,

--- a/JSONAPI/ActionFilters/EnableSortingAttribute.cs
+++ b/JSONAPI/ActionFilters/EnableSortingAttribute.cs
@@ -69,7 +69,7 @@ namespace JSONAPI.ActionFilters
         {
             var selectors = new List<Tuple<bool, Expression<Func<T, object>>>>();
 
-            var usedProperties = new Dictionary<PropertyInfo, object>();
+            var usedProperties = new Dictionary<ModelProperty, object>();
 
             var sortExpressions = sortParam.Split(',');
             foreach (var sortExpression in sortExpressions)
@@ -98,7 +98,7 @@ namespace JSONAPI.ActionFilters
                 usedProperties[property] = null;
 
                 var paramExpr = Expression.Parameter(typeof (T));
-                var propertyExpr = Expression.Property(paramExpr, property);
+                var propertyExpr = Expression.Property(paramExpr, property.Property);
                 var selector = Expression.Lambda<Func<T, object>>(propertyExpr, paramExpr);
 
                 selectors.Add(Tuple.Create(ascending, selector));

--- a/JSONAPI/Core/IModelManager.cs
+++ b/JSONAPI/Core/IModelManager.cs
@@ -41,14 +41,6 @@ namespace JSONAPI.Core
         Type GetTypeByResourceTypeName(string resourceTypeName);
 
         /// <summary>
-        /// Returns the key that will be used to represent the given property in serialized
-        /// JSON. Inverse of GetPropertyForJsonKey.
-        /// </summary>
-        /// <param name="propInfo">The serializable property</param>
-        /// <returns>The string denoting the given property within a JSON document.</returns>
-        string GetJsonKeyForProperty(PropertyInfo propInfo); //TODO: Do we need to have a type parameter here, in case the property is inherited?
-
-        /// <summary>
         /// Returns the property corresponding to a given JSON Key. Inverse of GetJsonKeyForProperty.
         /// </summary>
         /// <param name="type">The Type to find the property on</param>

--- a/JSONAPI/Core/IModelManager.cs
+++ b/JSONAPI/Core/IModelManager.cs
@@ -54,7 +54,7 @@ namespace JSONAPI.Core
         /// <param name="type">The Type to find the property on</param>
         /// <param name="jsonKey">The JSON key representing a property</param>
         /// <returns></returns>
-        PropertyInfo GetPropertyForJsonKey(Type type, string jsonKey);
+        ModelProperty GetPropertyForJsonKey(Type type, string jsonKey);
 
         /// <summary>
         /// Analogue to System.Type.GetProperties(), but made available so that any caching done
@@ -62,8 +62,7 @@ namespace JSONAPI.Core
         /// </summary>
         /// <param name="type">The type to get properties from</param>
         /// <returns>All properties recognized by the IModelManager.</returns>
-        //TODO: This needs to include JsonIgnore'd properties, so that they can be found and explicitly included at runtime...confusing? Add another method that excludes these?
-        PropertyInfo[] GetProperties(Type type);
+        ModelProperty[] GetProperties(Type type);
 
         /// <summary>
         /// Determines whether or not the given type will be treated as a "Many" relationship. 

--- a/JSONAPI/Core/ModelManager.cs
+++ b/JSONAPI/Core/ModelManager.cs
@@ -1,12 +1,11 @@
-﻿using JSONAPI.Attributes;
-using JSONAPI.Json;
+﻿using System.Collections.ObjectModel;
+using JSONAPI.Attributes;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using JSONAPI.Extensions;
+using Newtonsoft.Json;
 
 namespace JSONAPI.Core
 {
@@ -15,6 +14,8 @@ namespace JSONAPI.Core
         public ModelManager(IPluralizationService pluralizationService)
         {
             _pluralizationService = pluralizationService;
+            RegistrationsByName = new Dictionary<string, TypeRegistration>();
+            RegistrationsByType = new Dictionary<Type, TypeRegistration>();
         }
 
         protected IPluralizationService _pluralizationService = null;
@@ -28,25 +29,36 @@ namespace JSONAPI.Core
 
         #region Cache storage
 
-        protected Lazy<Dictionary<Type, PropertyInfo>> _idProperties
-            = new Lazy<Dictionary<Type,PropertyInfo>>(
-                () => new Dictionary<Type, PropertyInfo>()
-            );
+        /// <summary>
+        /// Represents a type's registration with a model manager
+        /// </summary>
+        protected sealed class TypeRegistration
+        {
+            internal TypeRegistration() { }
 
-        protected Lazy<Dictionary<Type, Dictionary<string, PropertyInfo>>> _propertyMaps
-            = new Lazy<Dictionary<Type, Dictionary<string, PropertyInfo>>>(
-                () => new Dictionary<Type, Dictionary<string, PropertyInfo>>()
-            );
+            /// <summary>
+            /// The type that has been registered
+            /// </summary>
+            public Type Type { get; internal set; }
 
-        protected Lazy<Dictionary<Type, string>> _resourceTypeNamesByType
-            = new Lazy<Dictionary<Type, string>>(
-                () => new Dictionary<Type, string>()
-            );
+            /// <summary>
+            /// The serialized format of the type's name
+            /// </summary>
+            public string ResourceTypeName { get; internal set; }
 
-        protected Lazy<Dictionary<string, Type>> _typesByResourceTypeName
-            = new Lazy<Dictionary<string, Type>>(
-                () => new Dictionary<string, Type>()
-            );
+            /// <summary>
+            /// The property to be used as this type's ID.
+            /// </summary>
+            public PropertyInfo IdProperty { get; internal set; }
+
+            /// <summary>
+            /// A resource's properties, keyed by name.
+            /// </summary>
+            public IReadOnlyDictionary<string, ModelProperty> Properties { get; internal set; }
+        }
+
+        protected readonly IDictionary<string, TypeRegistration> RegistrationsByName;
+        protected readonly IDictionary<Type, TypeRegistration> RegistrationsByType; 
 
         protected Lazy<Dictionary<Type, bool>> _isSerializedAsMany
             = new Lazy<Dictionary<Type, bool>>(
@@ -60,101 +72,62 @@ namespace JSONAPI.Core
 
         #endregion
 
-        #region Id property determination
-
         public PropertyInfo GetIdProperty(Type type)
         {
-            PropertyInfo idprop = null;
-
-            var idPropCache = _idProperties.Value;
-
-            lock (idPropCache)
-            {
-                if (idPropCache.TryGetValue(type, out idprop)) return idprop;
-
-                // First, look for UseAsIdAttribute
-                idprop = type.GetProperties()
-                .Where(p => p.CustomAttributes.Any(attr => attr.AttributeType == typeof(UseAsIdAttribute)))
-                .FirstOrDefault();
-                if (idprop == null)
-                {
-                    idprop = type.GetProperty("Id");
-                }
-
-                if (idprop == null)
-                    throw new InvalidOperationException(String.Format("Unable to determine Id property for type {0}", type));
-
-                idPropCache.Add(type, idprop);
-            }
-
-            return idprop;
+            return GetRegistrationByType(type).IdProperty;
         }
 
-        #endregion
-
-        #region Property Maps
-
-        protected IDictionary<string, PropertyInfo> GetPropertyMap(Type type)
+        public ModelProperty[] GetProperties(Type type)
         {
-            Dictionary<string, PropertyInfo> propMap = null;
-
-            var propMapCache = _propertyMaps.Value;
-
-            lock (propMapCache)
-            {
-                if (propMapCache.TryGetValue(type, out propMap)) return propMap;
-
-                propMap = new Dictionary<string, PropertyInfo>();
-                PropertyInfo[] props = type.GetProperties();
-                foreach (PropertyInfo prop in props)
-                {
-                    propMap[GetJsonKeyForProperty(prop)] = prop;
-                }
-
-                propMapCache.Add(type, propMap);
-            }
-
-            return propMap;
+            var typeRegistration = GetRegistrationByType(type);
+            return typeRegistration.Properties.Values.ToArray();
         }
 
-        public PropertyInfo[] GetProperties(Type type)
+        public ModelProperty GetPropertyForJsonKey(Type type, string jsonKey)
         {
-            return GetPropertyMap(type).Values.ToArray();
+            var typeRegistration = GetRegistrationByType(type);
+            ModelProperty property;
+            return (typeRegistration.Properties.TryGetValue(jsonKey, out property)) ? property : null;
         }
-
-        public PropertyInfo GetPropertyForJsonKey(Type type, string jsonKey)
-        {
-            PropertyInfo propInfo;
-            if (GetPropertyMap(type).TryGetValue(jsonKey, out propInfo)) return propInfo;
-            else return null; // Or, throw an exception here??
-        }
-
-        #endregion
 
         public string GetResourceTypeNameForType(Type type)
         {
-            if (IsSerializedAsMany(type))
-                type = GetElementType(type);
-
-            var currentType = type;
-            while (currentType != null && currentType != typeof(Object))
-            {
-                string resourceTypeName;
-                if (_resourceTypeNamesByType.Value.TryGetValue(currentType, out resourceTypeName)) return resourceTypeName;
-
-                // This particular type wasn't registered, but maybe the base type was
-                currentType = currentType.BaseType;
-            }
-
-            throw new InvalidOperationException(String.Format("The type `{0}` was not registered.", type.FullName));
+            return GetRegistrationByType(type).ResourceTypeName;
         }
 
         public Type GetTypeByResourceTypeName(string resourceTypeName)
         {
-            Type type;
-            if (_typesByResourceTypeName.Value.TryGetValue(resourceTypeName, out type)) return type;
+            lock (RegistrationsByName)
+            {
+                TypeRegistration typeRegistration;
+                if (RegistrationsByName.TryGetValue(resourceTypeName, out typeRegistration))
+                    return typeRegistration.Type;
 
-            throw new InvalidOperationException(String.Format("The resource type name `{0}` was not registered.", resourceTypeName));
+                throw new InvalidOperationException(String.Format("The resource type name `{0}` was not registered.",
+                    resourceTypeName));
+            }
+        }
+
+        private TypeRegistration GetRegistrationByType(Type type)
+        {
+            lock (RegistrationsByType)
+            {
+                if (IsSerializedAsMany(type))
+                    type = GetElementType(type);
+
+                var currentType = type;
+                while (currentType != null && currentType != typeof(Object))
+                {
+                    TypeRegistration registration;
+                    if (RegistrationsByType.TryGetValue(currentType, out registration))
+                        return registration;
+
+                    // This particular type wasn't registered, but maybe the base type was.
+                    currentType = currentType.BaseType;
+                }
+            }
+
+            throw new InvalidOperationException(String.Format("The type `{0}` was not registered.", type.FullName));
         }
 
         /// <summary>
@@ -174,22 +147,81 @@ namespace JSONAPI.Core
         /// <param name="resourceTypeName">The resource type name to use</param>
         public void RegisterResourceType(Type type, string resourceTypeName)
         {
-            lock (_resourceTypeNamesByType.Value)
+            lock (RegistrationsByType)
             {
-                lock (_typesByResourceTypeName.Value)
+                lock (RegistrationsByName)
                 {
-                    if (_resourceTypeNamesByType.Value.ContainsKey(type))
+                    if (RegistrationsByType.ContainsKey(type))
                         throw new InvalidOperationException(String.Format("The type `{0}` has already been registered.",
                             type.FullName));
 
-                    if (_typesByResourceTypeName.Value.ContainsKey(resourceTypeName))
+                    if (RegistrationsByName.ContainsKey(resourceTypeName))
                         throw new InvalidOperationException(
                             String.Format("The resource type name `{0}` has already been registered.", resourceTypeName));
 
-                    _resourceTypeNamesByType.Value[type] = resourceTypeName;
-                    _typesByResourceTypeName.Value[resourceTypeName] = type;
+                    var registration = new TypeRegistration
+                    {
+                        Type = type,
+                        ResourceTypeName = resourceTypeName
+                    };
+
+                    var propertyMap = new Dictionary<string, ModelProperty>();
+
+                    var idProperty = CalculateIdProperty(type);
+                    if (idProperty == null)
+                        throw new InvalidOperationException(String.Format(
+                            "Unable to determine Id property for type {0}", type));
+
+                    registration.IdProperty = idProperty;
+
+                    var props = type.GetProperties();
+                    foreach (var prop in props)
+                    {
+                        var jsonKey = prop == registration.IdProperty
+                            ? "id"
+                            : GetJsonKeyForProperty(prop);
+                        var property = CreateModelProperty(prop, jsonKey);
+                        propertyMap[jsonKey] = property;
+                    }
+
+                    registration.Properties = new ReadOnlyDictionary<string, ModelProperty>(propertyMap);
+
+
+                    RegistrationsByType.Add(type, registration);
+                    RegistrationsByName.Add(resourceTypeName, registration);
                 }
             }
+        }
+
+        /// <summary>
+        /// Creates a cacheable model property representation from a PropertyInfo
+        /// </summary>
+        /// <param name="prop">The property</param>
+        /// <param name="jsonKey">The key that this model property will be serialized as</param>
+        /// <returns>A model property represenation</returns>
+        protected virtual ModelProperty CreateModelProperty(PropertyInfo prop, string jsonKey)
+        {
+            var type = prop.PropertyType;
+            var ignoreByDefault =
+                prop.CustomAttributes.Any(c => c.AttributeType == typeof(JsonIgnoreAttribute));
+
+            if (prop.PropertyType.CanWriteAsJsonApiAttribute())
+                return new FieldModelProperty(prop, jsonKey, ignoreByDefault);
+
+            var isToMany =
+                type.IsArray ||
+                (type.GetInterfaces().Contains(typeof(System.Collections.IEnumerable)) && type.IsGenericType);
+
+            Type relatedType;
+            if (isToMany)
+            {
+                relatedType = type.IsGenericType ? type.GetGenericArguments()[0] : type.GetElementType();
+            }
+            else
+            {
+                relatedType = type;
+            }
+            return new RelationshipModelProperty(prop, jsonKey, ignoreByDefault, relatedType, isToMany);
         }
 
         /// <summary>
@@ -265,5 +297,18 @@ namespace JSONAPI.Core
             return etype;
         }
 
+        /// <summary>
+        /// Calculates the ID property for a given resource type.
+        /// </summary>
+        /// <param name="type">The type to use to calculate the ID for</param>
+        /// <returns>The ID property to use for this type</returns>
+        protected virtual PropertyInfo CalculateIdProperty(Type type)
+        {
+            return
+                type
+                    .GetProperties()
+                    .FirstOrDefault(p => p.CustomAttributes.Any(attr => attr.AttributeType == typeof(UseAsIdAttribute)))
+                ?? type.GetProperty("Id");
+        }
     }
 }

--- a/JSONAPI/Core/ModelProperty.cs
+++ b/JSONAPI/Core/ModelProperty.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+
+namespace JSONAPI.Core
+{
+    /// <summary>
+    /// Stores a model's property and its usage.
+    /// </summary>
+    public abstract class ModelProperty
+    {
+        internal ModelProperty(PropertyInfo property, string jsonKey, bool ignoreByDefault)
+        {
+            IgnoreByDefault = ignoreByDefault;
+            JsonKey = jsonKey;
+            Property = property;
+        }
+
+        /// <summary>
+        /// The PropertyInfo backing this ModelProperty
+        /// </summary>
+        public PropertyInfo Property { get; private set; }
+
+        /// <summary>
+        /// The key that will be used to represent this property in JSON API documents
+        /// </summary>
+        public string JsonKey { get; private set; }
+
+        /// <summary>
+        /// Whether this property should be ignored by default for serialization.
+        /// </summary>
+        public bool IgnoreByDefault { get; private set; }
+    }
+
+    /// <summary>
+    /// A ModelProperty representing a flat field on a resource object
+    /// </summary>
+    public sealed class FieldModelProperty : ModelProperty
+    {
+        internal FieldModelProperty(PropertyInfo property, string jsonKey, bool ignoreByDefault)
+            : base(property, jsonKey, ignoreByDefault)
+        {
+        }
+    }
+
+    /// <summary>
+    /// A ModelProperty representing a relationship to another resource
+    /// </summary>
+    public class RelationshipModelProperty : ModelProperty
+    {
+        internal RelationshipModelProperty(PropertyInfo property, string jsonKey, bool ignoreByDefault, Type relatedType, bool isToMany)
+            : base(property, jsonKey, ignoreByDefault)
+        {
+            RelatedType = relatedType;
+            IsToMany = isToMany;
+        }
+
+        /// <summary>
+        /// The type of resource found on the other side of this relationship
+        /// </summary>
+        public Type RelatedType { get; private set; }
+
+        /// <summary>
+        /// Whether the property represents a to-many (true) or to-one (false) relationship
+        /// </summary>
+        public bool IsToMany { get; private set; }
+    }
+}

--- a/JSONAPI/JSONAPI.csproj
+++ b/JSONAPI/JSONAPI.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Core\IMaterializer.cs" />
     <Compile Include="Core\MetadataManager.cs" />
     <Compile Include="Core\ModelManager.cs" />
+    <Compile Include="Core\ModelProperty.cs" />
     <Compile Include="Extensions\StringExtensions.cs" />
     <Compile Include="Extensions\TypeExtensions.cs" />
     <Compile Include="Http\ApiController.cs" />

--- a/JSONAPI/Json/JsonApiFormatter.cs
+++ b/JSONAPI/Json/JsonApiFormatter.cs
@@ -277,7 +277,7 @@ namespace JSONAPI.Json
                 }
                 if (skip) continue;
 
-                writer.WritePropertyName(_modelManager.GetJsonKeyForProperty(prop));
+                writer.WritePropertyName(relationshipModelProperty.JsonKey);
 
                 // Now look for enumerable-ness:
                 if (typeof(IEnumerable<Object>).IsAssignableFrom(prop.PropertyType))


### PR DESCRIPTION
Summary of changes:

1. `ModelManager` now discovers everything it needs to know about a type's properties when that type is registered, rather than when the type is first (de)serialized. Closes #82 
2. `GetProperties()` now returns a wrapper class for `PropertyInfo` called `ModelProperty`, which stores the `PropertyInfo` as well as the serialized json key and whether the property should be ignored by default in serialization. This class is abstract and has two child classes: `FieldModelProperty` and `RelationshipModelProperty`. The latter tracks the cardinality of the relationship as well as the related type.
3. `GetPropertyForJsonKey()` returns a `ModelProperty`.
4. `GetJsonKeyForProperty` is gone from `IModelManager`. Any code that was using this can use the field on `ModelProperty` instead.
5. You can now override a property's json key by adding a `[JsonProperty]` attribute. Closes #87 
6. Attempting to filter by an unknown field will return a 400 error, rather than performing no filter.
7. Models that use `[UseAsId]` to specify the id property no longer serialize the property both as `id` and as the property's formatted name. I feel that this is a bad practice due to not being compatible with a 1:1 mapping of json key to property, and would require special handling to make work given these new changes. Furthermore, ember data would probably squawk if you change a regular field and the server's response comes back with a new id. If a user really wants this they can accomplish it by adding a surrogate `Id` field in their model class, removing `[UseAsId]`, and ensuring that the two are the same.

This PR should improve performance and make finding bugs in one's models easier, by moving several calculations to registration time that previously didn't happen until requests are made. It also puts the model manager in charge of some concerns that used to be in the formatter's domain, but really ought to be part of the registration process. Most significantly, the formatter no longer needs to figure out whether a property is for a field or a relationship every time that property has to be serialized.

@SphtKr Do you have any feedback before I merge? I have some more work I want to get in that depends on this, but I want to make sure this meets your approval first.
