### PR TITLE
Add partial support for pagination

### DIFF
--- a/JSONAPI.Tests/ActionFilters/DefaultPaginationTransformerTests.cs
+++ b/JSONAPI.Tests/ActionFilters/DefaultPaginationTransformerTests.cs
@@ -1,0 +1,176 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Web.Http;
+using FluentAssertions;
+using JSONAPI.ActionFilters;
+using JSONAPI.Core;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace JSONAPI.Tests.ActionFilters
+{
+    [TestClass]
+    public class DefaultPaginationTransformerTests
+    {
+        private class Dummy
+        {
+            // ReSharper disable UnusedAutoPropertyAccessor.Local
+            public string Id { get; set; }
+            // ReSharper restore UnusedAutoPropertyAccessor.Local
+
+            public string FirstName { get; set; }
+
+            public string LastName { get; set; }
+        }
+
+        private IList<Dummy> _fixtures;
+        private IQueryable<Dummy> _fixturesQuery;
+
+        [TestInitialize]
+        public void SetupFixtures()
+        {
+            _fixtures = new List<Dummy>
+            {
+                new Dummy { Id = "1", FirstName = "Thomas", LastName = "Paine" },
+                new Dummy { Id = "2", FirstName = "Samuel", LastName = "Adams" },
+                new Dummy { Id = "3", FirstName = "George", LastName = "Washington"},
+                new Dummy { Id = "4", FirstName = "Thomas", LastName = "Jefferson" },
+                new Dummy { Id = "5", FirstName = "Martha", LastName = "Washington"},
+                new Dummy { Id = "6", FirstName = "Abraham", LastName = "Lincoln" },
+                new Dummy { Id = "7", FirstName = "Andrew", LastName = "Jackson" },
+                new Dummy { Id = "8", FirstName = "Andrew", LastName = "Johnson" },
+                new Dummy { Id = "9", FirstName = "William", LastName = "Harrison" }
+            };
+            _fixturesQuery = _fixtures.AsQueryable();
+        }
+
+        private DefaultPaginationTransformer GetTransformer(int maxPageSize)
+        {
+            return new DefaultPaginationTransformer("page.number", "page.size", maxPageSize);
+        }
+            
+        private Dummy[] GetArray(string uri, int maxPageSize = 50)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, uri);
+            return GetTransformer(maxPageSize).ApplyPagination(_fixturesQuery, request).ToArray();
+        }
+
+        [TestMethod]
+        public void ApplyPagination_has_no_effect_when_no_paging_parameters_are_supplied()
+        {
+            var array = GetArray("http://api.example.com/dummies");
+            array.Length.Should().Be(9);
+        }
+
+        [TestMethod]
+        public void ApplyPagination_returns_all_results_when_they_are_within_page()
+        {
+            var array = GetArray("http://api.example.com/dummies?page[number]=0&page[size]=10");
+            array.Length.Should().Be(9);
+        }
+
+        [TestMethod]
+        public void ApplyPagination_returns_no_results_when_page_size_is_zero()
+        {
+            var array = GetArray("http://api.example.com/dummies?page[number]=0&page[size]=0");
+            array.Length.Should().Be(0);
+        }
+
+        [TestMethod]
+        public void ApplyPagination_returns_first_page_of_data()
+        {
+            var array = GetArray("http://api.example.com/dummies?page[number]=0&page[size]=4");
+            array.Should().BeEquivalentTo(_fixtures[0], _fixtures[1], _fixtures[2], _fixtures[3]);
+        }
+
+        [TestMethod]
+        public void ApplyPagination_returns_second_page_of_data()
+        {
+            var array = GetArray("http://api.example.com/dummies?page[number]=1&page[size]=4");
+            array.Should().BeEquivalentTo(_fixtures[4], _fixtures[5], _fixtures[6], _fixtures[7]);
+        }
+
+        [TestMethod]
+        public void ApplyPagination_returns_page_at_end()
+        {
+            var array = GetArray("http://api.example.com/dummies?page[number]=2&page[size]=4");
+            array.Should().BeEquivalentTo(_fixtures[8]);
+        }
+
+        [TestMethod]
+        public void ApplyPagination_returns_nothing_for_page_after_end()
+        {
+            var array = GetArray("http://api.example.com/dummies?page[number]=3&page[size]=4");
+            array.Length.Should().Be(0);
+        }
+
+        [TestMethod]
+        public void ApplyPagination_uses_max_page_size_when_requested_page_size_is_higher()
+        {
+            var array = GetArray("http://api.example.com/dummies?page[number]=1&page[size]=8", 3);
+            array.Should().BeEquivalentTo(_fixtures[3], _fixtures[4], _fixtures[5]);
+        }
+
+        [TestMethod]
+        public void ApplyPagination_returns_400_if_page_number_is_negative()
+        {
+            Action action = () =>
+            {
+                GetArray("http://api.example.com/dummies?page[number]=-4&page[size]=4");
+            };
+            action.ShouldThrow<HttpResponseException>().And.Response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        }
+
+        [TestMethod]
+        public void ApplyPagination_returns_400_if_page_size_is_negative()
+        {
+            Action action = () =>
+            {
+                GetArray("http://api.example.com/dummies?page[number]=0&page[size]=-4");
+            };
+            action.ShouldThrow<HttpResponseException>().And.Response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        }
+
+        [TestMethod]
+        public void ApplyPagination_returns_400_if_page_number_specified_but_not_size()
+        {
+            Action action = () =>
+            {
+                GetArray("http://api.example.com/dummies?page[number]=0");
+            };
+            action.ShouldThrow<HttpResponseException>().And.Response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        }
+
+        [TestMethod]
+        public void ApplyPagination_returns_400_if_page_size_specified_but_not_number()
+        {
+            Action action = () =>
+            {
+                GetArray("http://api.example.com/dummies?page[size]=0");
+            };
+            action.ShouldThrow<HttpResponseException>().And.Response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        }
+
+        [TestMethod]
+        public void DefaultPaginationTransformer_cannot_be_instantiated_if_max_page_size_is_zero()
+        {
+            Action action = () =>
+            {
+                GetTransformer(0);
+            };
+            action.ShouldThrow<ArgumentOutOfRangeException>();
+        }
+
+        [TestMethod]
+        public void DefaultPaginationTransformer_cannot_be_instantiated_if_max_page_size_is_negative()
+        {
+            Action action = () =>
+            {
+                GetTransformer(-4);
+            };
+            action.ShouldThrow<ArgumentOutOfRangeException>();
+        }
+    }
+}

--- a/JSONAPI.Tests/JSONAPI.Tests.csproj
+++ b/JSONAPI.Tests/JSONAPI.Tests.csproj
@@ -79,6 +79,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ActionFilters\DefaultPaginationTransformerTests.cs" />
     <Compile Include="ActionFilters\QueryableTransformerTestsBase.cs" />
     <Compile Include="ActionFilters\DefaultSortingTransformerTests.cs" />
     <Compile Include="ActionFilters\DefaultFilteringTransformerTests.cs" />

--- a/JSONAPI/ActionFilters/DefaultPaginationTransformer.cs
+++ b/JSONAPI/ActionFilters/DefaultPaginationTransformer.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Web.Http;
+
+namespace JSONAPI.ActionFilters
+{
+    /// <summary>
+    /// Performs pagination a
+    /// </summary>
+    public class DefaultPaginationTransformer : IQueryablePaginationTransformer
+    {
+        private const int DefaultPageSize = 100;
+
+        private readonly string _pageNumberQueryParam;
+        private readonly string _pageSizeQueryParam;
+        private readonly int? _maxPageSize;
+
+        /// <summary>
+        /// Creates a DefaultPaginationTransformer
+        /// </summary>
+        /// <param name="pageNumberQueryParam">The query parameter to use to indicate the page number</param>
+        /// <param name="pageSizeQueryParam">The query parameter to use to indicate the page size</param>
+        /// <param name="maxPageSize">The maximum page size to allow clients to request. Leave null for no restriction.</param>
+        public DefaultPaginationTransformer(string pageNumberQueryParam, string pageSizeQueryParam, int? maxPageSize = null)
+        {
+            if (maxPageSize <= 0) throw new ArgumentOutOfRangeException("maxPageSize", "The maximum page size must be 1 or greater.");
+
+            _pageNumberQueryParam = pageNumberQueryParam;
+            _pageSizeQueryParam = pageSizeQueryParam;
+            _maxPageSize = maxPageSize;
+        }
+
+        public IQueryable<T> ApplyPagination<T>(IQueryable<T> query, HttpRequestMessage request)
+        {
+            var hasPageNumberParam = false;
+            var hasPageSizeParam = false;
+            var pageNumber = 0;
+            var pageSize = _maxPageSize ?? DefaultPageSize;
+            foreach (var kvp in request.GetQueryNameValuePairs())
+            {
+                if (kvp.Key == _pageNumberQueryParam)
+                {
+                    hasPageNumberParam = true;
+                    if (!int.TryParse(kvp.Value, out pageNumber)) throw new HttpResponseException(HttpStatusCode.BadRequest);
+                }
+                else if (kvp.Key == _pageSizeQueryParam)
+                {
+                    hasPageSizeParam = true;
+                    if (!int.TryParse(kvp.Value, out pageSize)) throw new HttpResponseException(HttpStatusCode.BadRequest);
+                }
+            }
+
+            if (!hasPageNumberParam && !hasPageSizeParam)
+                return query;
+
+            if ((hasPageNumberParam && !hasPageSizeParam) || (!hasPageNumberParam && hasPageSizeParam))
+                throw new HttpResponseException(HttpStatusCode.BadRequest);
+
+            if (pageNumber < 0 || pageSize < 0)
+                throw new HttpResponseException(HttpStatusCode.BadRequest);
+
+            if (_maxPageSize != null && pageSize > _maxPageSize.Value)
+                pageSize = _maxPageSize.Value;
+
+            var skip = pageNumber * pageSize;
+            return query.Skip(skip).Take(pageSize);
+        }
+    }
+}

--- a/JSONAPI/ActionFilters/IQueryablePaginationTransformer.cs
+++ b/JSONAPI/ActionFilters/IQueryablePaginationTransformer.cs
@@ -1,0 +1,20 @@
+﻿using System.Linq;
+using System.Net.Http;
+
+namespace JSONAPI.ActionFilters
+{
+    /// <summary>
+    /// Provides a service to provide a page of data based on information from the request.
+    /// </summary>
+    public interface IQueryablePaginationTransformer
+    {
+        /// <summary>
+        /// Pages the query according to information from the request.
+        /// </summary>
+        /// <param name="query">The query to page</param>
+        /// <param name="request">The request message</param>
+        /// <typeparam name="T">The queryable element type</typeparam>
+        /// <returns>An IQueryable configured to return a page of data</returns>
+        IQueryable<T> ApplyPagination<T>(IQueryable<T> query, HttpRequestMessage request);
+    }
+}

--- a/JSONAPI/ActionFilters/JsonApiQueryableAttribute.cs
+++ b/JSONAPI/ActionFilters/JsonApiQueryableAttribute.cs
@@ -19,6 +19,7 @@ namespace JSONAPI.ActionFilters
         private readonly IQueryableEnumerationTransformer _enumerationTransformer;
         private readonly IQueryableFilteringTransformer _filteringTransformer;
         private readonly IQueryableSortingTransformer _sortingTransformer;
+        private readonly IQueryablePaginationTransformer _paginationTransformer;
 
         /// <summary>
         /// Creates a new JsonApiQueryableAttribute.
@@ -26,12 +27,15 @@ namespace JSONAPI.ActionFilters
         /// <param name="enumerationTransformer">The transform to be used for enumerating IQueryable payloads.</param>
         /// <param name="filteringTransformer">The transform to be used for filtering IQueryable payloads</param>
         /// <param name="sortingTransformer">The transform to be used for sorting IQueryable payloads.</param>
+        /// <param name="paginationTransformer">The transform to be used for pagination of IQueryable payloads.</param>
         public JsonApiQueryableAttribute(
             IQueryableEnumerationTransformer enumerationTransformer,
             IQueryableFilteringTransformer filteringTransformer = null,
-            IQueryableSortingTransformer sortingTransformer = null)
+            IQueryableSortingTransformer sortingTransformer = null,
+            IQueryablePaginationTransformer paginationTransformer = null)
         {
             _sortingTransformer = sortingTransformer;
+            _paginationTransformer = paginationTransformer;
             _enumerationTransformer = enumerationTransformer;
             _filteringTransformer = filteringTransformer;
         }
@@ -97,6 +101,9 @@ namespace JSONAPI.ActionFilters
 
             if (_sortingTransformer != null)
                 query = _sortingTransformer.Sort(query, request);
+
+            if (_paginationTransformer != null)
+                query = _paginationTransformer.ApplyPagination(query, request);
 
             return await _enumerationTransformer.Enumerate(query, cancellationToken);
         }

--- a/JSONAPI/JSONAPI.csproj
+++ b/JSONAPI/JSONAPI.csproj
@@ -67,8 +67,10 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ActionFilters\DefaultFilteringTransformer.cs" />
+    <Compile Include="ActionFilters\DefaultPaginationTransformer.cs" />
     <Compile Include="ActionFilters\IQueryableEnumerationTransformer.cs" />
     <Compile Include="ActionFilters\IQueryableFilteringTransformer.cs" />
+    <Compile Include="ActionFilters\IQueryablePaginationTransformer.cs" />
     <Compile Include="ActionFilters\IQueryableSortingTransformer.cs" />
     <Compile Include="ActionFilters\JsonApiQueryableAttribute.cs" />
     <Compile Include="ActionFilters\QueryableTransformException.cs" />


### PR DESCRIPTION
This adds partial support for the [pagination feature of json-api](http://jsonapi.org/format/#fetching-pagination). `JsonApiQueryableAttribute` now takes an `IQueryablePaginationTransformer` parameter which works similarly to the filtering and sorting transformers. `JsonApiQueryableAttribute` will call the `IQueryablePaginationTransformer`'s `ApplyPagination` method after sorting.

When using fluent configuration, the default `IQueryablePaginationTransformer` is provided as `DefaultPaginationTransformer`. This implementation performs pagination based on a customizable pair of query parameters, which default to "page[number]" and "page[size]". An option is also available to set a maximum page size. If the user wants to specify their own implementation they can do so using `JsonApiConfiguration.PageWith()`.

The main thing that is missing from full support of the spec is the inclusion of pagination urls in `links` objects. I have a separate branch in the works that is a general refactor of jsonapi.net internals. The changes in that branch should afford greater flexibility to system components in setting response payload metadata. Once that is merged then it should be easy to cover the rest of the json-api spec regarding pagination.