### PR TITLE
Adding globalization for decimal, double and single for conversion.

### DIFF
--- a/JSONAPI.Tests/ActionFilters/DefaultFilteringTransformerTests.cs
+++ b/JSONAPI.Tests/ActionFilters/DefaultFilteringTransformerTests.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Threading;
 using System.Web.Http;
 using FluentAssertions;
 using JSONAPI.ActionFilters;
@@ -690,6 +692,19 @@ namespace JSONAPI.Tests.ActionFilters
         }
 
         [TestMethod]
+        public void Filters_by_matching_decimal_property_non_en_US()
+        {
+            var currentCulture = Thread.CurrentThread.CurrentCulture;
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("se-SE");
+
+            var returnedArray = GetArray("http://api.example.com/dummies?filter[decimal-field]=4.03");
+            returnedArray.Length.Should().Be(1);
+            returnedArray[0].Id.Should().Be("170");
+
+            Thread.CurrentThread.CurrentCulture = currentCulture;
+        }
+
+        [TestMethod]
         public void Filters_by_missing_decimal_property()
         {
             var returnedArray = GetArray("http://api.example.com/dummies?filter[decimal-field]=");
@@ -1040,6 +1055,20 @@ namespace JSONAPI.Tests.ActionFilters
         }
 
         [TestMethod]
+        public void Filters_by_matching_single_property_non_en_US()
+        {
+            var currentCulture = Thread.CurrentThread.CurrentCulture;
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("se-SE");
+
+            var returnedArray = GetArray("http://api.example.com/dummies?filter[single-field]=21.56901");
+            returnedArray.Length.Should().Be(1);
+            returnedArray[0].Id.Should().Be("370");
+
+            Thread.CurrentThread.CurrentCulture = currentCulture;
+        }
+
+
+        [TestMethod]
         public void Filters_by_missing_single_property()
         {
             var returnedArray = GetArray("http://api.example.com/dummies?filter[single-field]=");
@@ -1072,6 +1101,19 @@ namespace JSONAPI.Tests.ActionFilters
             var returnedArray = GetArray("http://api.example.com/dummies?filter[double-field]=12.3453489012");
             returnedArray.Length.Should().Be(1);
             returnedArray[0].Id.Should().Be("390");
+        }
+
+        [TestMethod]
+        public void Filters_by_matching_double_property_non_en_US()
+        {
+            var currentCulture = Thread.CurrentThread.CurrentCulture;
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("se-SE");
+
+            var returnedArray = GetArray("http://api.example.com/dummies?filter[double-field]=12.3453489012");
+            returnedArray.Length.Should().Be(1);
+            returnedArray[0].Id.Should().Be("390");
+
+            Thread.CurrentThread.CurrentCulture = currentCulture;
         }
 
         [TestMethod]

--- a/JSONAPI.Tests/Core/ResourceTypeRegistrarTests.cs
+++ b/JSONAPI.Tests/Core/ResourceTypeRegistrarTests.cs
@@ -7,7 +7,9 @@ using System.Reflection;
 using System.Collections.Generic;
 using System.Collections;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
+using System.Threading;
 using FluentAssertions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -559,6 +561,24 @@ namespace JSONAPI.Tests.Core
             AssertAttribute(reg, "decimal-field", "0", 0m, "0", g => g.DecimalField);
             AssertAttribute(reg, "decimal-field", "20000000000.1234", 20000000000.1234m, "20000000000.1234", g => g.DecimalField);
             AssertAttribute(reg, "decimal-field", null, 0m, "0", g => g.DecimalField);
+        }
+
+        [TestMethod]
+        public void BuildRegistration_sets_up_correct_attribute_for_Decimal_field_non_en_US()
+        {
+            // Set up non US culture
+            var culture = Thread.CurrentThread.CurrentCulture;
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("se-SE");
+
+            // Arrange
+            var registrar = new ResourceTypeRegistrar(new DefaultNamingConventions(new PluralizationService()));
+
+            // Act
+            var reg = registrar.BuildRegistration(typeof(AttributeGrabBag));
+
+            AssertAttribute(reg, "decimal-field", "20000000000.1234", 20000000000.1234m, "20000000000.1234", g => g.DecimalField);
+
+            Thread.CurrentThread.CurrentCulture = culture;
         }
 
         [TestMethod]

--- a/JSONAPI/Core/DecimalAttributeValueConverter.cs
+++ b/JSONAPI/Core/DecimalAttributeValueConverter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Reflection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -26,7 +27,14 @@ namespace JSONAPI.Core
         {
             var value = _property.GetValue(resource);
             if (value == null) return null;
-            return value.ToString();
+            try
+            {
+                return ((Decimal)value).ToString(CultureInfo.InvariantCulture);
+            }
+            catch (InvalidCastException e)
+            {
+                throw new JsonSerializationException("Could not serialize decimal value.", e);
+            }
         }
 
         public void SetValue(object resource, JToken value)
@@ -37,7 +45,7 @@ namespace JSONAPI.Core
             {
                 var stringTokenValue = value.Value<string>();
                 Decimal d;
-                if (!Decimal.TryParse(stringTokenValue, out d))
+                if (!Decimal.TryParse(stringTokenValue, NumberStyles.Any, CultureInfo.InvariantCulture, out d))
                     throw new JsonSerializationException("Could not parse decimal value.");
                 _property.SetValue(resource, d);
             }

--- a/JSONAPI/QueryableTransformers/DefaultFilteringTransformer.cs
+++ b/JSONAPI/QueryableTransformers/DefaultFilteringTransformer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Net;
@@ -248,40 +249,40 @@ namespace JSONAPI.QueryableTransformers
             else if (propertyType == typeof(Single))
             {
                 Single value;
-                expr = Single.TryParse(queryValue, out value)
+                expr = Single.TryParse(queryValue, NumberStyles.Any, CultureInfo.InvariantCulture, out value)
                     ? GetPropertyExpression(value, prop, param)
                     : Expression.Constant(false);
             }
             else if (propertyType == typeof(Single?))
             {
                 Single tmp;
-                var value = Single.TryParse(queryValue, out tmp) ? tmp : (Single?)null;
+                var value = Single.TryParse(queryValue, NumberStyles.Any, CultureInfo.InvariantCulture, out tmp) ? tmp : (Single?)null;
                 expr = GetPropertyExpression(value, prop, param);
             }
             else if (propertyType == typeof(Double))
             {
                 Double value;
-                expr = Double.TryParse(queryValue, out value)
+                expr = Double.TryParse(queryValue, NumberStyles.Any, CultureInfo.InvariantCulture, out value)
                     ? GetPropertyExpression(value, prop, param)
                     : Expression.Constant(false);
             }
             else if (propertyType == typeof(Double?))
             {
                 Double tmp;
-                var value = Double.TryParse(queryValue, out tmp) ? tmp : (Double?)null;
+                var value = Double.TryParse(queryValue, NumberStyles.Any, CultureInfo.InvariantCulture, out tmp) ? tmp : (Double?)null;
                 expr = GetPropertyExpression(value, prop, param);
             }
             else if (propertyType == typeof(Decimal))
             {
                 Decimal value;
-                expr = Decimal.TryParse(queryValue, out value)
+                expr = Decimal.TryParse(queryValue, NumberStyles.Any, CultureInfo.InvariantCulture, out value)
                     ? GetPropertyExpression(value, prop, param)
                     : Expression.Constant(false);
             }
             else if (propertyType == typeof(Decimal?))
             {
                 Decimal tmp;
-                var value = Decimal.TryParse(queryValue, out tmp) ? tmp : (Decimal?)null;
+                var value = Decimal.TryParse(queryValue, NumberStyles.Any, CultureInfo.InvariantCulture, out tmp) ? tmp : (Decimal?)null;
                 expr = GetPropertyExpression(value, prop, param);
             }
             else if (propertyType == typeof(DateTime))


### PR DESCRIPTION
Found a bug for the FilteringTransformer and the Value Converter for Decimals, doubles and singles. In some cultures, such as se-SE, the decimal point is formatted as a comma (,). I don't remember which spec is says so in but I'm pretty sure that URIs and JSON wants non-localized formatting on those.

Added some regression tests that you can test out (without my changes) to see it fail.