### PR TITLE
Sorting

### DIFF
--- a/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp/DocumentMaterializers/StarshipDocumentMaterializer.cs
+++ b/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp/DocumentMaterializers/StarshipDocumentMaterializer.cs
@@ -21,10 +21,11 @@ namespace JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.DocumentMaterializer
             TestDbContext dbContext,
             IQueryableResourceCollectionDocumentBuilder queryableResourceCollectionDocumentBuilder,
             IBaseUrlService baseUrlService, ISingleResourceDocumentBuilder singleResourceDocumentBuilder,
+            ISortExpressionExtractor sortExpressionExtractor,
             IQueryableEnumerationTransformer queryableEnumerationTransformer, IResourceTypeRegistry resourceTypeRegistry)
             : base(
                 queryableResourceCollectionDocumentBuilder, baseUrlService, singleResourceDocumentBuilder,
-                queryableEnumerationTransformer, resourceTypeRegistry)
+                queryableEnumerationTransformer, sortExpressionExtractor, resourceTypeRegistry)
         {
             _dbContext = dbContext;
         }

--- a/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp/DocumentMaterializers/StarshipOfficersRelatedResourceMaterializer.cs
+++ b/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp/DocumentMaterializers/StarshipOfficersRelatedResourceMaterializer.cs
@@ -6,6 +6,7 @@ using JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.Models;
 using JSONAPI.Core;
 using JSONAPI.Documents.Builders;
 using JSONAPI.EntityFramework.Http;
+using JSONAPI.Http;
 
 namespace JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.DocumentMaterializers
 {
@@ -15,8 +16,9 @@ namespace JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.DocumentMaterializer
 
         public StarshipOfficersRelatedResourceMaterializer(ResourceTypeRelationship relationship, DbContext dbContext,
             IQueryableResourceCollectionDocumentBuilder queryableResourceCollectionDocumentBuilder,
+            ISortExpressionExtractor sortExpressionExtractor,
             IResourceTypeRegistration primaryTypeRegistration)
-            : base(relationship, dbContext, queryableResourceCollectionDocumentBuilder, primaryTypeRegistration)
+            : base(relationship, dbContext, queryableResourceCollectionDocumentBuilder, sortExpressionExtractor, primaryTypeRegistration)
         {
             _dbContext = dbContext;
         }

--- a/JSONAPI.Autofac/JsonApiAutofacModule.cs
+++ b/JSONAPI.Autofac/JsonApiAutofacModule.cs
@@ -157,6 +157,8 @@ namespace JSONAPI.Autofac
             builder.RegisterType<JsonApiExceptionFilterAttribute>().SingleInstance();
             builder.RegisterType<DefaultQueryableResourceCollectionDocumentBuilder>().As<IQueryableResourceCollectionDocumentBuilder>();
 
+            // Misc
+            builder.RegisterType<DefaultSortExpressionExtractor>().As<ISortExpressionExtractor>().SingleInstance();
         }
     }
 }

--- a/JSONAPI.EntityFramework/Http/EntityFrameworkToManyRelatedResourceDocumentMaterializer.cs
+++ b/JSONAPI.EntityFramework/Http/EntityFrameworkToManyRelatedResourceDocumentMaterializer.cs
@@ -28,8 +28,9 @@ namespace JSONAPI.EntityFramework.Http
             ResourceTypeRelationship relationship,
             DbContext dbContext,
             IQueryableResourceCollectionDocumentBuilder queryableResourceCollectionDocumentBuilder,
+            ISortExpressionExtractor sortExpressionExtractor,
             IResourceTypeRegistration primaryTypeRegistration)
-            : base(queryableResourceCollectionDocumentBuilder)
+            : base(queryableResourceCollectionDocumentBuilder, sortExpressionExtractor)
         {
             _relationship = relationship;
             _dbContext = dbContext;

--- a/JSONAPI.Tests/Documents/Builders/FallbackDocumentBuilderTests.cs
+++ b/JSONAPI.Tests/Documents/Builders/FallbackDocumentBuilderTests.cs
@@ -43,9 +43,12 @@ namespace JSONAPI.Tests.Documents.Builders
             var mockBaseUrlService = new Mock<IBaseUrlService>(MockBehavior.Strict);
             mockBaseUrlService.Setup(s => s.GetBaseUrl(request)).Returns("https://www.example.com");
 
+            var mockSortExpressionExtractor = new Mock<ISortExpressionExtractor>(MockBehavior.Strict);
+            mockSortExpressionExtractor.Setup(e => e.ExtractSortExpressions(request)).Returns(new [] { "id "});
+
             // Act
             var fallbackDocumentBuilder = new FallbackDocumentBuilder(singleResourceDocumentBuilder.Object,
-                mockQueryableDocumentBuilder.Object, mockResourceCollectionDocumentBuilder.Object, mockBaseUrlService.Object);
+                mockQueryableDocumentBuilder.Object, mockResourceCollectionDocumentBuilder.Object, mockSortExpressionExtractor.Object, mockBaseUrlService.Object);
             var resultDocument = await fallbackDocumentBuilder.BuildDocument(objectContent, request, cancellationTokenSource.Token);
 
             // Assert
@@ -70,19 +73,24 @@ namespace JSONAPI.Tests.Documents.Builders
 
             var mockBaseUrlService = new Mock<IBaseUrlService>(MockBehavior.Strict);
             mockBaseUrlService.Setup(s => s.GetBaseUrl(request)).Returns("https://www.example.com/");
+
+            var sortExpressions = new[] { "id" };
             
             var cancellationTokenSource = new CancellationTokenSource();
 
             var mockQueryableDocumentBuilder = new Mock<IQueryableResourceCollectionDocumentBuilder>(MockBehavior.Strict);
             mockQueryableDocumentBuilder
-                .Setup(b => b.BuildDocument(items, request, cancellationTokenSource.Token, null))
+                .Setup(b => b.BuildDocument(items, request, sortExpressions, cancellationTokenSource.Token, null))
                 .Returns(Task.FromResult(mockDocument.Object));
 
             var mockResourceCollectionDocumentBuilder = new Mock<IResourceCollectionDocumentBuilder>(MockBehavior.Strict);
 
+            var mockSortExpressionExtractor = new Mock<ISortExpressionExtractor>(MockBehavior.Strict);
+            mockSortExpressionExtractor.Setup(e => e.ExtractSortExpressions(request)).Returns(sortExpressions);
+
             // Act
             var fallbackDocumentBuilder = new FallbackDocumentBuilder(singleResourceDocumentBuilder.Object,
-                mockQueryableDocumentBuilder.Object, mockResourceCollectionDocumentBuilder.Object, mockBaseUrlService.Object);
+                mockQueryableDocumentBuilder.Object, mockResourceCollectionDocumentBuilder.Object, mockSortExpressionExtractor.Object, mockBaseUrlService.Object);
             var resultDocument = await fallbackDocumentBuilder.BuildDocument(items, request, cancellationTokenSource.Token);
 
             // Assert
@@ -116,9 +124,12 @@ namespace JSONAPI.Tests.Documents.Builders
                 .Setup(b => b.BuildDocument(items, "https://www.example.com/", It.IsAny<string[]>(), It.IsAny<IMetadata>(), null))
                 .Returns(() => (mockDocument.Object));
 
+            var mockSortExpressionExtractor = new Mock<ISortExpressionExtractor>(MockBehavior.Strict);
+            mockSortExpressionExtractor.Setup(e => e.ExtractSortExpressions(request)).Returns(new[] { "id " });
+
             // Act
             var fallbackDocumentBuilder = new FallbackDocumentBuilder(singleResourceDocumentBuilder.Object,
-                mockQueryableDocumentBuilder.Object, mockResourceCollectionDocumentBuilder.Object, mockBaseUrlService.Object);
+                mockQueryableDocumentBuilder.Object, mockResourceCollectionDocumentBuilder.Object, mockSortExpressionExtractor.Object, mockBaseUrlService.Object);
             var resultDocument = await fallbackDocumentBuilder.BuildDocument(items, request, cancellationTokenSource.Token);
 
             // Assert

--- a/JSONAPI.Tests/Http/DefaultSortExpressionExtractorTests.cs
+++ b/JSONAPI.Tests/Http/DefaultSortExpressionExtractorTests.cs
@@ -1,0 +1,86 @@
+﻿using System.Net.Http;
+using FluentAssertions;
+using JSONAPI.Http;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace JSONAPI.Tests.Http
+{
+    [TestClass]
+    public class DefaultSortExpressionExtractorTests
+    {
+        [TestMethod]
+        public void ExtractsSingleSortExpressionFromUri()
+        {
+            // Arrange
+            const string uri = "http://api.example.com/dummies?sort=first-name";
+            var request = new HttpRequestMessage(HttpMethod.Get, uri);
+
+            // Act
+            var extractor = new DefaultSortExpressionExtractor();
+            var sortExpressions = extractor.ExtractSortExpressions(request);
+
+            // Assert
+            sortExpressions.Should().BeEquivalentTo("first-name");
+        }
+
+        [TestMethod]
+        public void ExtractsSingleDescendingSortExpressionFromUri()
+        {
+            // Arrange
+            const string uri = "http://api.example.com/dummies?sort=-first-name";
+            var request = new HttpRequestMessage(HttpMethod.Get, uri);
+
+            // Act
+            var extractor = new DefaultSortExpressionExtractor();
+            var sortExpressions = extractor.ExtractSortExpressions(request);
+
+            // Assert
+            sortExpressions.Should().BeEquivalentTo("-first-name");
+        }
+
+        [TestMethod]
+        public void ExtractsMultipleSortExpressionsFromUri()
+        {
+            // Arrange
+            const string uri = "http://api.example.com/dummies?sort=last-name,first-name";
+            var request = new HttpRequestMessage(HttpMethod.Get, uri);
+
+            // Act
+            var extractor = new DefaultSortExpressionExtractor();
+            var sortExpressions = extractor.ExtractSortExpressions(request);
+
+            // Assert
+            sortExpressions.Should().BeEquivalentTo("last-name", "first-name");
+        }
+
+        [TestMethod]
+        public void ExtractsMultipleSortExpressionsFromUriWithDifferentDirections()
+        {
+            // Arrange
+            const string uri = "http://api.example.com/dummies?sort=last-name,-first-name";
+            var request = new HttpRequestMessage(HttpMethod.Get, uri);
+
+            // Act
+            var extractor = new DefaultSortExpressionExtractor();
+            var sortExpressions = extractor.ExtractSortExpressions(request);
+
+            // Assert
+            sortExpressions.Should().BeEquivalentTo("last-name", "-first-name");
+        }
+
+        [TestMethod]
+        public void ExtractsNothingWhenThereIsNoSortParam()
+        {
+            // Arrange
+            const string uri = "http://api.example.com/dummies";
+            var request = new HttpRequestMessage(HttpMethod.Get, uri);
+
+            // Act
+            var extractor = new DefaultSortExpressionExtractor();
+            var sortExpressions = extractor.ExtractSortExpressions(request);
+
+            // Assert
+            sortExpressions.Length.Should().Be(0);
+        }
+    }
+}

--- a/JSONAPI.Tests/JSONAPI.Tests.csproj
+++ b/JSONAPI.Tests/JSONAPI.Tests.csproj
@@ -90,6 +90,7 @@
     <Compile Include="Core\ResourceTypeRegistrarTests.cs" />
     <Compile Include="Core\ResourceTypeRegistryTests.cs" />
     <Compile Include="Extensions\TypeExtensionsTests.cs" />
+    <Compile Include="Http\DefaultSortExpressionExtractorTests.cs" />
     <Compile Include="Json\JsonApiFormatterTests.cs" />
     <Compile Include="Models\Author.cs" />
     <Compile Include="Models\Comment.cs" />

--- a/JSONAPI/Documents/Builders/DefaultQueryableResourceCollectionDocumentBuilder.cs
+++ b/JSONAPI/Documents/Builders/DefaultQueryableResourceCollectionDocumentBuilder.cs
@@ -38,11 +38,11 @@ namespace JSONAPI.Documents.Builders
             _baseUrlService = baseUrlService;
         }
 
-        public async Task<IResourceCollectionDocument> BuildDocument<T>(IQueryable<T> query, HttpRequestMessage request, CancellationToken cancellationToken,
+        public async Task<IResourceCollectionDocument> BuildDocument<T>(IQueryable<T> query, HttpRequestMessage request, string[] sortExpressions, CancellationToken cancellationToken,
             string[] includes = null)
         {
             var filteredQuery = _filteringTransformer.Filter(query, request);
-            var sortedQuery = _sortingTransformer.Sort(filteredQuery, request);
+            var sortedQuery = _sortingTransformer.Sort(filteredQuery, sortExpressions);
 
             var paginationResults = _paginationTransformer.ApplyPagination(sortedQuery, request);
             var paginatedQuery = paginationResults.PagedQuery;

--- a/JSONAPI/Documents/Builders/FallbackDocumentBuilder.cs
+++ b/JSONAPI/Documents/Builders/FallbackDocumentBuilder.cs
@@ -17,6 +17,7 @@ namespace JSONAPI.Documents.Builders
         private readonly ISingleResourceDocumentBuilder _singleResourceDocumentBuilder;
         private readonly IQueryableResourceCollectionDocumentBuilder _queryableResourceCollectionDocumentBuilder;
         private readonly IResourceCollectionDocumentBuilder _resourceCollectionDocumentBuilder;
+        private readonly ISortExpressionExtractor _sortExpressionExtractor;
         private readonly IBaseUrlService _baseUrlService;
         private readonly Lazy<MethodInfo> _openBuildDocumentFromQueryableMethod;
         private readonly Lazy<MethodInfo> _openBuildDocumentFromEnumerableMethod;
@@ -27,11 +28,13 @@ namespace JSONAPI.Documents.Builders
         public FallbackDocumentBuilder(ISingleResourceDocumentBuilder singleResourceDocumentBuilder,
             IQueryableResourceCollectionDocumentBuilder queryableResourceCollectionDocumentBuilder,
             IResourceCollectionDocumentBuilder resourceCollectionDocumentBuilder,
+            ISortExpressionExtractor sortExpressionExtractor,
             IBaseUrlService baseUrlService)
         {
             _singleResourceDocumentBuilder = singleResourceDocumentBuilder;
             _queryableResourceCollectionDocumentBuilder = queryableResourceCollectionDocumentBuilder;
             _resourceCollectionDocumentBuilder = resourceCollectionDocumentBuilder;
+            _sortExpressionExtractor = sortExpressionExtractor;
             _baseUrlService = baseUrlService;
 
             _openBuildDocumentFromQueryableMethod =
@@ -60,8 +63,10 @@ namespace JSONAPI.Documents.Builders
                 var buildDocumentMethod =
                     _openBuildDocumentFromQueryableMethod.Value.MakeGenericMethod(queryableElementType);
 
+                var sortExpressions = _sortExpressionExtractor.ExtractSortExpressions(requestMessage);
+
                 dynamic materializedQueryTask = buildDocumentMethod.Invoke(_queryableResourceCollectionDocumentBuilder,
-                    new[] { obj, requestMessage, cancellationToken, null });
+                    new[] { obj, requestMessage, sortExpressions, cancellationToken, null });
 
                 return await materializedQueryTask;
             }

--- a/JSONAPI/Documents/Builders/IQueryableResourceCollectionDocumentBuilder.cs
+++ b/JSONAPI/Documents/Builders/IQueryableResourceCollectionDocumentBuilder.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -16,11 +15,12 @@ namespace JSONAPI.Documents.Builders
         /// </summary>
         /// <param name="query">The query to materialize to build the response document</param>
         /// <param name="request">The request containing parameters to determine how to sort/filter/paginate the query</param>
+        /// <param name="sortExpressions">An array of paths to sort by</param>
         /// <param name="cancellationToken"></param>
         /// <param name="includePaths">The set of paths to include in the compound document</param>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        Task<IResourceCollectionDocument> BuildDocument<T>(IQueryable<T> query, HttpRequestMessage request, CancellationToken cancellationToken,
+        Task<IResourceCollectionDocument> BuildDocument<T>(IQueryable<T> query, HttpRequestMessage request, string[] sortExpressions, CancellationToken cancellationToken,
             string[] includePaths = null);
     }
 }

--- a/JSONAPI/Http/DefaultSortExpressionExtractor.cs
+++ b/JSONAPI/Http/DefaultSortExpressionExtractor.cs
@@ -1,0 +1,21 @@
+﻿using System.Linq;
+using System.Net.Http;
+
+namespace JSONAPI.Http
+{
+    /// <summary>
+    /// Default implementation of <see cref="ISortExpressionExtractor" />
+    /// </summary>
+    public class DefaultSortExpressionExtractor : ISortExpressionExtractor
+    {
+        private const string SortQueryParamKey = "sort";
+
+        public string[] ExtractSortExpressions(HttpRequestMessage requestMessage)
+        {
+            var queryParams = requestMessage.GetQueryNameValuePairs();
+            var sortParam = queryParams.FirstOrDefault(kvp => kvp.Key == SortQueryParamKey);
+            if (sortParam.Key != SortQueryParamKey) return new string[] {};
+            return sortParam.Value.Split(',');
+        }
+    }
+}

--- a/JSONAPI/Http/ISortExpressionExtractor.cs
+++ b/JSONAPI/Http/ISortExpressionExtractor.cs
@@ -1,0 +1,17 @@
+﻿using System.Net.Http;
+
+namespace JSONAPI.Http
+{
+    /// <summary>
+    /// Service to extract sort expressions from an HTTP request
+    /// </summary>
+    public interface ISortExpressionExtractor
+    {
+        /// <summary>
+        /// Extracts sort expressions from the request
+        /// </summary>
+        /// <param name="requestMessage"></param>
+        /// <returns></returns>
+        string[] ExtractSortExpressions(HttpRequestMessage requestMessage);
+    }
+}

--- a/JSONAPI/Http/MappedDocumentMaterializer.cs
+++ b/JSONAPI/Http/MappedDocumentMaterializer.cs
@@ -71,6 +71,9 @@ namespace JSONAPI.Http
             var jsonApiPaths = includePaths.Select(ConvertToJsonKeyPath).ToArray();
             var mappedQuery = GetMappedQuery(entityQuery, includePaths);
             var sortationPaths = _sortExpressionExtractor.ExtractSortExpressions(request);
+            if (sortationPaths == null || !sortationPaths.Any())
+                sortationPaths = GetDefaultSortExpressions();
+
             return await _queryableResourceCollectionDocumentBuilder.BuildDocument(mappedQuery, request, sortationPaths, cancellationToken, jsonApiPaths);
         }
 
@@ -115,6 +118,15 @@ namespace JSONAPI.Http
         protected virtual Expression<Func<TDto, object>>[] GetIncludePathsForSingleResource()
         {
             return null;
+        }
+
+        /// <summary>
+        /// Hook for specifying sort expressions when fetching a collection
+        /// </summary>
+        /// <returns></returns>
+        protected virtual string[] GetDefaultSortExpressions()
+        {
+            return new[] { "id" };
         }
 
         /// <summary>

--- a/JSONAPI/Http/QueryableToManyRelatedResourceDocumentMaterializer.cs
+++ b/JSONAPI/Http/QueryableToManyRelatedResourceDocumentMaterializer.cs
@@ -33,6 +33,8 @@ namespace JSONAPI.Http
             var query = await GetRelatedQuery(primaryResourceId, cancellationToken);
             var includes = GetIncludePaths();
             var sortExpressions = _sortExpressionExtractor.ExtractSortExpressions(request);
+            if (sortExpressions == null || sortExpressions.Length < 1)
+                sortExpressions = GetDefaultSortExpressions();
             return await _queryableResourceCollectionDocumentBuilder.BuildDocument(query, request, sortExpressions, cancellationToken, includes); // TODO: allow implementors to specify metadata
         }
 
@@ -46,6 +48,15 @@ namespace JSONAPI.Http
         /// </summary>
         /// <returns></returns>
         protected virtual string[] GetIncludePaths()
+        {
+            return null;
+        }
+
+        /// <summary>
+        /// If the client doesn't request any sort expressions, these expressions will be used for sorting instead.
+        /// </summary>
+        /// <returns></returns>
+        protected virtual string[] GetDefaultSortExpressions()
         {
             return null;
         }

--- a/JSONAPI/Http/QueryableToManyRelatedResourceDocumentMaterializer.cs
+++ b/JSONAPI/Http/QueryableToManyRelatedResourceDocumentMaterializer.cs
@@ -14,13 +14,17 @@ namespace JSONAPI.Http
     public abstract class QueryableToManyRelatedResourceDocumentMaterializer<TRelated> : IRelatedResourceDocumentMaterializer
     {
         private readonly IQueryableResourceCollectionDocumentBuilder _queryableResourceCollectionDocumentBuilder;
+        private readonly ISortExpressionExtractor _sortExpressionExtractor;
 
         /// <summary>
         /// Creates a new QueryableRelatedResourceDocumentMaterializer
         /// </summary>
-        protected QueryableToManyRelatedResourceDocumentMaterializer(IQueryableResourceCollectionDocumentBuilder queryableResourceCollectionDocumentBuilder)
+        protected QueryableToManyRelatedResourceDocumentMaterializer(
+            IQueryableResourceCollectionDocumentBuilder queryableResourceCollectionDocumentBuilder,
+            ISortExpressionExtractor sortExpressionExtractor)
         {
             _queryableResourceCollectionDocumentBuilder = queryableResourceCollectionDocumentBuilder;
+            _sortExpressionExtractor = sortExpressionExtractor;
         }
 
         public async Task<IJsonApiDocument> GetRelatedResourceDocument(string primaryResourceId, HttpRequestMessage request,
@@ -28,7 +32,8 @@ namespace JSONAPI.Http
         {
             var query = await GetRelatedQuery(primaryResourceId, cancellationToken);
             var includes = GetIncludePaths();
-            return await _queryableResourceCollectionDocumentBuilder.BuildDocument(query, request, cancellationToken, includes); // TODO: allow implementors to specify metadata
+            var sortExpressions = _sortExpressionExtractor.ExtractSortExpressions(request);
+            return await _queryableResourceCollectionDocumentBuilder.BuildDocument(query, request, sortExpressions, cancellationToken, includes); // TODO: allow implementors to specify metadata
         }
 
         /// <summary>

--- a/JSONAPI/JSONAPI.csproj
+++ b/JSONAPI/JSONAPI.csproj
@@ -84,9 +84,11 @@
     <Compile Include="Core\ResourceTypeRelationship.cs" />
     <Compile Include="Core\ToManyResourceTypeRelationship.cs" />
     <Compile Include="Core\ToOneResourceTypeRelationship.cs" />
+    <Compile Include="Http\DefaultSortExpressionExtractor.cs" />
     <Compile Include="Http\DocumentMaterializerLocator.cs" />
     <Compile Include="Http\IDocumentMaterializerLocator.cs" />
     <Compile Include="Http\IRelatedResourceDocumentMaterializer.cs" />
+    <Compile Include="Http\ISortExpressionExtractor.cs" />
     <Compile Include="Http\MappedDocumentMaterializer.cs" />
     <Compile Include="Http\QueryableToManyRelatedResourceDocumentMaterializer.cs" />
     <Compile Include="Http\QueryableToOneRelatedResourceDocumentMaterializer.cs" />

--- a/JSONAPI/QueryableTransformers/DefaultSortingTransformer.cs
+++ b/JSONAPI/QueryableTransformers/DefaultSortingTransformer.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Net.Http;
 using System.Reflection;
 using JSONAPI.Core;
 using JSONAPI.Documents.Builders;
@@ -25,22 +24,10 @@ namespace JSONAPI.QueryableTransformers
             _resourceTypeRegistry = resourceTypeRegistry;
         }
         
-        private const string SortQueryParamKey = "sort";
-
-        public IOrderedQueryable<T> Sort<T>(IQueryable<T> query, HttpRequestMessage request)
+        public IOrderedQueryable<T> Sort<T>(IQueryable<T> query, string[] sortExpressions)
         {
-            var queryParams = request.GetQueryNameValuePairs();
-            var sortParam = queryParams.FirstOrDefault(kvp => kvp.Key == SortQueryParamKey);
-
-            string[] sortExpressions;
-            if (sortParam.Key != SortQueryParamKey)
-            {
-                sortExpressions = new[] { "id" }; // We have to sort by something, so make it the ID.
-            }
-            else
-            {
-                sortExpressions = sortParam.Value.Split(',');
-            }
+            if (sortExpressions == null || sortExpressions.Length == 0)
+                sortExpressions = new [] { "id" };
 
             var selectors = new List<ISelector<T>>();
             var usedProperties = new Dictionary<PropertyInfo, object>();

--- a/JSONAPI/QueryableTransformers/IQueryableSortingTransformer.cs
+++ b/JSONAPI/QueryableTransformers/IQueryableSortingTransformer.cs
@@ -12,9 +12,9 @@ namespace JSONAPI.QueryableTransformers
         /// Sorts the provided queryable based on information from the request message.
         /// </summary>
         /// <param name="query">The input query</param>
-        /// <param name="request">The request message</param>
+        /// <param name="sortExpressions">The expressions to sort by</param>
         /// <typeparam name="T">The element type of the query</typeparam>
         /// <returns>The sorted query</returns>
-        IOrderedQueryable<T> Sort<T>(IQueryable<T> query, HttpRequestMessage request);
+        IOrderedQueryable<T> Sort<T>(IQueryable<T> query, string[] sortExpressions);
     }
 }


### PR DESCRIPTION
This PR gives materializers greater control over default sorting, by allowing them to specify a set of sort expressions. Additionally, `IQueryableSortingTransformer` has been simplified to no longer take a dependency on `HttpRequestMessage`. It now performs sorting based on a set of dot-separated string paths. Materializers can use the new `ISortExpressionExtractor` to extract these paths from the `HttpRequestMessage`.

This is part of an eventual goal to make `IQueryableResourceCollectionDocumentBuilder` independent of `HttpRequestMessage`.